### PR TITLE
Always-on light sleep, simplify auto-dim to brightness-only

### DIFF
--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -15,12 +15,10 @@ void knob_cb(lv_event_t *e);
 void knob_change(knob_event_t k,int cont);
 void knob_process_pending(void);
 bool activity_kick(void);
-bool knob_is_dimmed(void);
 void knob_notify_swipe_up(void);
 void knob_notify_swipe_down(void);
 void knob_notify_swipe_left(void);
 void knob_notify_swipe_right(void);
-void knob_notify_gpio_wakeup(void);
 float knob_read_battery_voltage(void);
 
 

--- a/knobby/knob_hw.c
+++ b/knobby/knob_hw.c
@@ -1,8 +1,6 @@
 #include "knob_hw.h"
 #include "knob_nvs.h"
-#include "bidi_switch_knob.h"
 #include "driver/ledc.h"
-#include "esp32-hal-cpu.h"
 
 // ---------- private constants ----------
 #define BACKLIGHT_PIN 47
@@ -27,8 +25,6 @@ static bool battery_sample_valid = false;
 static uint32_t last_activity_tick = 0;
 static uint32_t undim_tick = 0;
 static lv_timer_t *auto_dim_timer = NULL;
-/* Set when iot_knob_stop() is called on dim; cleared on resume to avoid double-resume errors. */
-static bool knob_polling_paused = false;
 
 // ---------- battery curve ----------
 static const float battery_curve_voltages[] = {
@@ -128,16 +124,9 @@ bool activity_kick(void)
     bool was_dimmed = dimmed;
     last_activity_tick = lv_tick_get();
     if (dimmed) {
-        // Resume encoder polling before restoring active state so the first loop
-        // iteration after undim can already process knob events.
-        if (knob_polling_paused) {
-            iot_knob_resume();
-            knob_polling_paused = false;
-        }
         if (auto_dim_timer != NULL) {
             lv_timer_resume(auto_dim_timer);
         }
-        setCpuFrequencyMhz(CPU_FREQ_ACTIVE);
         dimmed = false;
         undim_tick = last_activity_tick;
         brightness_apply();
@@ -150,11 +139,6 @@ bool in_undim_grace(void)
     return undim_tick != 0 && lv_tick_elaps(undim_tick) < UNDIM_GRACE_MS;
 }
 
-bool knob_is_dimmed(void)
-{
-    return dimmed;
-}
-
 static void auto_dim_timer_cb(lv_timer_t *timer)
 {
     (void)timer;
@@ -165,14 +149,9 @@ static void auto_dim_timer_cb(lv_timer_t *timer)
         uint32_t duty = (uint32_t)((AUTO_DIM_BRIGHTNESS * BACKLIGHT_DUTY_MAX) / 100);
         ledc_set_duty(BACKLIGHT_LEDC_MODE, BACKLIGHT_LEDC_CHANNEL, duty);
         ledc_update_duty(BACKLIGHT_LEDC_MODE, BACKLIGHT_LEDC_CHANNEL);
-        setCpuFrequencyMhz(CPU_FREQ_IDLE);
         if (auto_dim_timer != NULL) {
             lv_timer_pause(auto_dim_timer);
         }
-        // Stop 3 ms encoder polling timer while the device is dimmed; GPIO wakeup
-        // on the rotary pins still fires so the display can be woken by rotation.
-        iot_knob_stop();
-        knob_polling_paused = true;
     }
 }
 

--- a/knobby/knob_hw.c
+++ b/knobby/knob_hw.c
@@ -17,7 +17,7 @@
 
 // ---------- state ----------
 int brightness_percent = DEFAULT_BRIGHTNESS_PERCENT;
-bool auto_dim_enabled = false;
+int auto_dim_setting = AUTO_DIM_OFF;
 bool dimmed = false;
 float battery_voltage = 0.0f;
 int battery_percent = -1;
@@ -158,8 +158,9 @@ bool knob_is_dimmed(void)
 static void auto_dim_timer_cb(lv_timer_t *timer)
 {
     (void)timer;
-    if (!auto_dim_enabled || dimmed) return;
-    if (lv_tick_elaps(last_activity_tick) >= AUTO_DIM_TIMEOUT_MS) {
+    if (auto_dim_setting == AUTO_DIM_OFF || dimmed) return;
+    uint32_t timeout = auto_dim_ms[auto_dim_setting];
+    if (lv_tick_elaps(last_activity_tick) >= timeout) {
         dimmed = true;
         uint32_t duty = (uint32_t)((AUTO_DIM_BRIGHTNESS * BACKLIGHT_DUTY_MAX) / 100);
         ledc_set_duty(BACKLIGHT_LEDC_MODE, BACKLIGHT_LEDC_CHANNEL, duty);
@@ -181,7 +182,7 @@ void knob_hw_init(void)
     knob_nvs_init();
     brightness_init();
     brightness_percent = nvs_get_brightness();
-    auto_dim_enabled = nvs_get_auto_dim();
+    auto_dim_setting = nvs_get_auto_dim();
     last_activity_tick = lv_tick_get();
     auto_dim_timer = lv_timer_create(auto_dim_timer_cb, AUTO_DIM_CHECK_PERIOD_MS, NULL);
 }

--- a/knobby/knob_hw.h
+++ b/knobby/knob_hw.h
@@ -16,10 +16,7 @@ extern int battery_percent;
 #define AUTO_DIM_BRIGHTNESS     5       /* % brightness while dimmed */
 // UNDIM_GRACE_MS suppresses input for this long after wake to avoid accidental presses.
 #define UNDIM_GRACE_MS          150     /* ms */
-// Default active CPU frequency; some displays may be sensitive to lower CPU clocks.
-#define CPU_FREQ_ACTIVE         160     /* MHz – reduced for power; test for display stability */
-// 80 MHz is used while dimmed; lower values (e.g. 40) may be safe but are untested here.
-#define CPU_FREQ_IDLE           80      /* MHz – used during light sleep / dimmed state */
+#define CPU_FREQ_ACTIVE         160     /* MHz – APB bus stays 80 MHz at 80/160/240 */
 // Battery sample throttle: how often a fresh ADC measurement is allowed.
 #define BATTERY_SAMPLE_INTERVAL_MS  60000   /* ms between passive battery measurements */
 // Auto-dim check period: how often the inactivity timer fires.

--- a/knobby/knob_hw.h
+++ b/knobby/knob_hw.h
@@ -5,14 +5,13 @@
 
 // ---------- state ----------
 extern int brightness_percent;
-extern bool auto_dim_enabled;
+extern int auto_dim_setting;
 extern bool dimmed;
 extern float battery_voltage;
 extern int battery_percent;
 
 // ---------- tunable power / timing constants (shared) ----------
-// Increase AUTO_DIM_TIMEOUT_MS to reduce how often the device dims.
-#define AUTO_DIM_TIMEOUT_MS     30000   /* ms idle before display dims */
+// Auto-dim timeout is now configurable via NVS (see auto_dim_ms[] in knob_types.h).
 // Reducing AUTO_DIM_BRIGHTNESS below 5 further cuts backlight draw while dimmed.
 #define AUTO_DIM_BRIGHTNESS     5       /* % brightness while dimmed */
 // UNDIM_GRACE_MS suppresses input for this long after wake to avoid accidental presses.

--- a/knobby/knob_nvs.c
+++ b/knobby/knob_nvs.c
@@ -6,7 +6,7 @@
 // ---------- cached state ----------
 static bool settings_dirty = false;
 static int cached_brightness = DEFAULT_BRIGHTNESS_PERCENT;
-static bool cached_auto_dim = false;
+static int cached_auto_dim = AUTO_DIM_OFF;
 static int cached_color_mode = 0;
 static int cached_deselect_timeout = 0; /* index: 0=never, 1=5s, 2=15s, 3=30s */
 static int cached_orientation = ORIENTATION_MODE_ABSOLUTE;
@@ -40,7 +40,7 @@ void knob_nvs_init(void)
         nvs_get_i8(handle, "track", &pt_val);
         nvs_get_i16(handle, "life_total", &lt_val);
 
-        cached_auto_dim = (dim_val != 0);
+        cached_auto_dim = (dim_val < 0) ? 0 : (dim_val >= AUTO_DIM_COUNT) ? 0 : dim_val;
         cached_color_mode = lc_val;
         cached_deselect_timeout = (dt_val < 0) ? 0 : (dt_val > 3) ? 3 : dt_val;
         cached_orientation = (rot_val < 0) ? ORIENTATION_MODE_ABSOLUTE
@@ -66,7 +66,7 @@ int nvs_get_brightness(void)
     return cached_brightness;
 }
 
-bool nvs_get_auto_dim(void)
+int nvs_get_auto_dim(void)
 {
     return cached_auto_dim;
 }
@@ -78,9 +78,11 @@ void nvs_set_brightness(int value)
     settings_dirty = true;
 }
 
-void nvs_set_auto_dim(bool value)
+void nvs_set_auto_dim(int value)
 {
-    cached_auto_dim = value;
+    cached_auto_dim = (value < 0) ? AUTO_DIM_OFF
+                    : (value >= AUTO_DIM_COUNT) ? AUTO_DIM_OFF
+                    : value;
     settings_dirty = true;
 }
 
@@ -171,7 +173,7 @@ void settings_save(void)
     if (!settings_dirty) return;
     nvs_handle_t handle;
     if (nvs_open("knobby", NVS_READWRITE, &handle) == ESP_OK) {
-        nvs_set_i8(handle, "auto_dim", cached_auto_dim ? 1 : 0);
+        nvs_set_i8(handle, "auto_dim", (int8_t)cached_auto_dim);
         nvs_set_i8(handle, "brightness", (int8_t)cached_brightness);
         nvs_set_i8(handle, "color_mode", (int8_t)cached_color_mode);
         nvs_set_i8(handle, "desel_time", (int8_t)cached_deselect_timeout);

--- a/knobby/knob_nvs.h
+++ b/knobby/knob_nvs.h
@@ -8,8 +8,8 @@ void settings_save(void);
 
 int nvs_get_brightness(void);
 void nvs_set_brightness(int value);
-bool nvs_get_auto_dim(void);
-void nvs_set_auto_dim(bool value);
+int nvs_get_auto_dim(void);
+void nvs_set_auto_dim(int value);
 
 int nvs_get_color_mode(void);
 void nvs_set_color_mode(int value);

--- a/knobby/knob_scr_menus.c
+++ b/knobby/knob_scr_menus.c
@@ -152,7 +152,13 @@ static void set_btn_color(lv_obj_t *btn, uint32_t color)
     if (btn != NULL) lv_obj_set_style_bg_color(btn, lv_color_hex(color), 0);
 }
 
-static uint32_t autodim_color(bool on) { return on ? TOGGLE_ON : TOGGLE_OFF; }
+static uint32_t autodim_color(int index)
+{
+    static const uint32_t colors[AUTO_DIM_COUNT] = {
+        0x37474F, 0x1B5E20, 0x0D47A1, 0x4A148C  /* grey, green, blue, purple */
+    };
+    return (index >= 0 && index < AUTO_DIM_COUNT) ? colors[index] : 0x37474F;
+}
 static uint32_t orientation_color(int mode)
 {
     switch (mode) {
@@ -187,19 +193,29 @@ static void event_screen_brightness(lv_event_t *e)
     open_settings_screen();
 }
 
+static const char *autodim_label(int index)
+{
+    switch (index) {
+        case AUTO_DIM_15S: return "Auto-dim\n15s";
+        case AUTO_DIM_30S: return "Auto-dim\n30s";
+        case AUTO_DIM_60S: return "Auto-dim\n60s";
+        default:           return "Auto-dim\nOFF";
+    }
+}
+
 static void event_screen_autodim(lv_event_t *e)
 {
     (void)e;
-    auto_dim_enabled = !auto_dim_enabled;
-    nvs_set_auto_dim(auto_dim_enabled);
-    if (!auto_dim_enabled && dimmed) {
+    auto_dim_setting = (auto_dim_setting + 1) % AUTO_DIM_COUNT;
+    nvs_set_auto_dim(auto_dim_setting);
+    if (auto_dim_setting == AUTO_DIM_OFF && dimmed) {
         dimmed = false;
         brightness_apply();
     }
     if (label_autodim_quad) {
-        lv_label_set_text(label_autodim_quad, auto_dim_enabled ? "Auto-dim\nON" : "Auto-dim\nOFF");
+        lv_label_set_text(label_autodim_quad, autodim_label(auto_dim_setting));
     }
-    set_btn_color(btn_autodim, autodim_color(auto_dim_enabled));
+    set_btn_color(btn_autodim, autodim_color(auto_dim_setting));
 }
 
 static const char *color_mode_label(int mode)
@@ -333,7 +349,7 @@ void build_quad_menus(void)
 
     quad_item_t screen_items[4] = {
         {"Brightness", event_screen_brightness, true, LV_EVENT_CLICKED},
-        {auto_dim_enabled ? "Auto-dim\nON" : "Auto-dim\nOFF", event_screen_autodim, true, LV_EVENT_CLICKED},
+        {autodim_label(auto_dim_setting), event_screen_autodim, true, LV_EVENT_CLICKED},
         {"Battery",       event_screen_battery, true, LV_EVENT_CLICKED},
         {"More",          event_screen_more, true, LV_EVENT_CLICKED},
     };
@@ -341,7 +357,7 @@ void build_quad_menus(void)
 
     btn_autodim = lv_obj_get_child(screen_screen_settings_menu, 1);
     label_autodim_quad = lv_obj_get_child(btn_autodim, 0);
-    set_btn_color(btn_autodim, autodim_color(auto_dim_enabled));
+    set_btn_color(btn_autodim, autodim_color(auto_dim_setting));
 
     quad_item_t page2_items[4] = {
         {color_mode_label(nvs_get_color_mode()), event_screen_color_mode, true, LV_EVENT_CLICKED},

--- a/knobby/knob_types.h
+++ b/knobby/knob_types.h
@@ -28,6 +28,15 @@
 #define ORIENTATION_MODE_TABLETOP 2
 #define ORIENTATION_MODE_COUNT    3
 
+// ---------- auto-dim timeout options ----------
+#define AUTO_DIM_OFF  0
+#define AUTO_DIM_15S  1
+#define AUTO_DIM_30S  2
+#define AUTO_DIM_60S  3
+#define AUTO_DIM_COUNT 4
+
+static const uint32_t auto_dim_ms[] = {0, 15000, 30000, 60000};
+
 // ---------- deselect timeout options ----------
 #define DESELECT_NEVER 0
 #define DESELECT_5S    1

--- a/knobby/knob_types.h
+++ b/knobby/knob_types.h
@@ -79,7 +79,7 @@ static inline int clamp_life(int value)
 
 static inline int clamp_brightness(int value)
 {
-    if (value < 5) return 5;
+    if (value < 1) return 1;
     if (value > 100) return 100;
     return value;
 }

--- a/knobby/knobby.ino
+++ b/knobby/knobby.ino
@@ -82,55 +82,27 @@ void setup()
   // next-deadline value so the CPU only wakes when LVGL actually needs to run.
 }
 
-// Maximum time the CPU may sleep before LVGL must get a tick, even if no timer fires.
-// 2 seconds is conservative; LVGL's auto-dim check runs at 1 s so this is a safety net.
-#define LIGHT_SLEEP_MAX_MS 2000U
+// Minimum idle interval before using light sleep.
+// Below this threshold we fall back to vTaskDelay to avoid sleep/wake overhead.
+#define ACTIVE_SLEEP_MIN_MS 10U
 
 void loop()
 {
-  static bool lvgl_suspended_for_dim = false;
+  uint32_t time_till_next;
 
   knob_process_pending();
+  time_till_next = lv_timer_handler();
 
-  if (knob_is_dimmed()) {
-    uint32_t time_till_next = LIGHT_SLEEP_MAX_MS;
-
-    // While dimmed, avoid running LVGL timers and redraw work continuously.
-    // Wake sources are GPIO (touch/rotary) plus a bounded timer safety net.
-    lvgl_suspended_for_dim = true;
-
-    // Clamp the sleep duration: never sleep longer than LIGHT_SLEEP_MAX_MS, and always
-    // sleep at least 1 ms so we don't busy-spin if lv_timer_handler returns 0.
-    if (time_till_next == 0 || time_till_next > LIGHT_SLEEP_MAX_MS)
-      time_till_next = LIGHT_SLEEP_MAX_MS;
-
-    // Arm the hardware timer to the next LVGL deadline before entering light sleep.
-    esp_sleep_enable_timer_wakeup((uint64_t)time_till_next * 1000ULL);
-
-    // Set knob pin wakeup to opposite of current level so any rotation wakes us
+  if (time_till_next >= ACTIVE_SLEEP_MIN_MS) {
     uint8_t level_a = gpio_get_level((gpio_num_t)ROTARY_ENC_PIN_A);
     uint8_t level_b = gpio_get_level((gpio_num_t)ROTARY_ENC_PIN_B);
     gpio_wakeup_enable((gpio_num_t)ROTARY_ENC_PIN_A, level_a ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
     gpio_wakeup_enable((gpio_num_t)ROTARY_ENC_PIN_B, level_b ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
+    esp_sleep_enable_timer_wakeup((uint64_t)time_till_next * 1000ULL);
     esp_light_sleep_start();
-    // GPIO wake = user input (touch or rotary): undim and resume the encoder timer
-    // so knob events are processed on the next loop iteration.
-    // Timer wake = LVGL housekeeping only: stay dimmed, re-enter sleep next iteration.
-    if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_GPIO) {
-      knob_notify_gpio_wakeup();
-      activity_kick();
-    }
+    gpio_wakeup_disable((gpio_num_t)ROTARY_ENC_PIN_A);
+    gpio_wakeup_disable((gpio_num_t)ROTARY_ENC_PIN_B);
   } else {
-    uint32_t time_till_next;
-
-    if (lvgl_suspended_for_dim) {
-      lvgl_suspended_for_dim = false;
-      lv_refr_now(NULL);
-    }
-
-    time_till_next = lv_timer_handler();
-
-    // Disable knob pin wakeup when active so they don't interfere
     gpio_wakeup_disable((gpio_num_t)ROTARY_ENC_PIN_A);
     gpio_wakeup_disable((gpio_num_t)ROTARY_ENC_PIN_B);
     vTaskDelay(pdMS_TO_TICKS(time_till_next));

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -314,11 +314,6 @@ static bool tp_tracking = false;
 static bool tp_swiped = false;
 static lv_point_t tp_start = {0, 0};
 
-void knob_notify_gpio_wakeup(void)
-{
-  touch_irq_pending = true;
-}
-
 #define SWIPE_THRESHOLD 80
 #define SWIPE_MAX_LATERAL 120
 #define SWIPE_LEFT_EDGE_ZONE 80


### PR DESCRIPTION
**Summary**
- Replace the two-path main loop (active vs dimmed) with a single path that always uses ESP32 light sleep between LVGL frames
- Auto-dim now only changes backlight brightness — no more LVGL suspension, encoder stop/resume, or CPU frequency switching

**Background**
USB power meter testing showed that light sleep in the normal active loop achieves power draw within 0.01-0.02W of the old dedicated dimmed sleep path. The old path suspended LVGL, stopped encoder polling, dropped CPU to 80 MHz, and slept for up to 2 seconds — all unnecessary complexity.

CPU frequency (80/160/240 MHz) has only a minor impact on idle power because the RTOS already halts the CPU during vTaskDelay. Actual light sleep is what saves power.

**How it works**
Every loop iteration: knob_process_pending() → lv_timer_handler() → light sleep (if idle >= 10ms) or vTaskDelay() (if shorter). GPIO wakeup on touch + rotary encoder pins for instant responsiveness. Same path regardless of dim state.

The 150ms undim grace window (suppresses accidental input on wake) is preserved.

**Test plan**
- Verify auto-dim dims backlight after configured timeout
- Verify touch/knob undims instantly with no accidental input
- Verify power draw at 5% brightness idle (~0.36-0.38W)
- Verify no UI lag during active use (knob turns, screen transitions, event log scrolling)