### PR TITLE
Add support for player counter tracking (#9)

### DIFF
--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -98,6 +98,10 @@ static void handle_back_navigation(lv_obj_t *screen)
     } else if (screen == screen_player_name) {
         if (!name_screen_handle_back())
             open_multiplayer_menu_screen(multiplayer_menu_player);
+    } else if (screen == screen_player_counters_menu) {
+        open_multiplayer_menu_screen(multiplayer_menu_player);
+    } else if (screen == screen_player_counter_edit) {
+        open_multiplayer_counter_menu_screen();
     } else if (screen == screen_player_all_damage) {
         open_multiplayer_menu_screen(multiplayer_menu_player);
     }
@@ -121,6 +125,7 @@ void reset_all_values(void)
 
     refresh_rename_ui();
     refresh_multiplayer_all_damage_ui();
+    refresh_multiplayer_counter_edit_ui();
 }
 
 void knob_cb(lv_event_t *e)
@@ -145,6 +150,8 @@ void knob_gui(void)
     build_multiplayer_menu_screen();
     build_rename_screen();
     build_multiplayer_all_damage_screen();
+    build_multiplayer_counter_menu_screen();
+    build_multiplayer_counter_edit_screen();
     build_select_screen();
     build_damage_screen();
     build_settings_screen();
@@ -161,6 +168,7 @@ void knob_gui(void)
     refresh_select_ui();
     refresh_damage_ui();
     refresh_multiplayer_all_damage_ui();
+    refresh_multiplayer_counter_edit_ui();
     refresh_settings_ui();
 
     knob_timer_init();
@@ -210,6 +218,12 @@ static void handle_knob_event(knob_event_t k)
     {
         if (k == KNOB_LEFT)      change_custom_life(-1);
         else if (k == KNOB_RIGHT) change_custom_life(+1);
+    }
+    else if (lv_scr_act() == screen_player_counter_edit)
+    {
+        if (k == KNOB_LEFT)      change_multiplayer_counter_edit(-1);
+        else if (k == KNOB_RIGHT) change_multiplayer_counter_edit(+1);
+        refresh_multiplayer_counter_edit_ui();
     }
     else if (lv_scr_act() == screen_damage_log)
     {

--- a/knobby/knob_damage_log.c
+++ b/knobby/knob_damage_log.c
@@ -5,7 +5,7 @@
 typedef struct {
     uint32_t timestamp_ms;
     int8_t   player;       // target: -1 = single player, 0-3 = multiplayer index
-    int8_t   source;       // source for cmd damage, -1 if N/A
+    int8_t   source;       // source for cmd damage or counter type, -1 if N/A
     uint8_t  event_type;   // log_event_type_t
     int16_t  delta;
 } damage_log_entry_t;
@@ -70,12 +70,13 @@ void damage_log_undo_selected(void)
     buf_idx = (damage_log_head - 1 - damage_log_selected + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
     entry = &damage_log[buf_idx];
 
-    /* Reverse the life change */
-    undo_life_change(entry->player, entry->delta);
-
-    /* Reverse commander damage tracking */
-    if (entry->event_type == LOG_EVT_CMD_DAMAGE && entry->source >= 0) {
+    if (entry->event_type == LOG_EVT_LIFE) {
+        undo_life_change(entry->player, entry->delta);
+    } else if (entry->event_type == LOG_EVT_CMD_DAMAGE) {
+        undo_life_change(entry->player, entry->delta);
         undo_cmd_damage(entry->source, entry->player, entry->delta);
+    } else if (entry->event_type == LOG_EVT_COUNTER) {
+        undo_counter_change(entry->player, entry->source, entry->delta);
     }
 
     /* Remove entry by shifting newer entries down */
@@ -121,6 +122,16 @@ static void format_log_line(damage_log_entry_t *entry, char *buf, size_t buf_sz)
                  multiplayer_names[entry->source],
                  abs_delta,
                  multiplayer_names[entry->player]);
+    } else if (entry->event_type == LOG_EVT_COUNTER && entry->source >= 0 && entry->player >= 0) {
+        const counter_definition_t *definition = get_counter_definition((counter_type_t)entry->source);
+        const char *action = entry->delta > 0 ? "increased" : "decreased";
+        const char *counter_name = (definition != NULL) ? definition->display_name : "Counter";
+        snprintf(buf, buf_sz, "%s: %s %s %s by %d",
+                 time_str,
+                 multiplayer_names[entry->player],
+                 action,
+                 counter_name,
+                 abs_delta);
     } else if (entry->player < 0) {
         const char *action = entry->delta > 0 ? "gained" : "lost";
         snprintf(buf, buf_sz, "%s: %s %d life", time_str, action, abs_delta);
@@ -203,8 +214,14 @@ static void refresh_damage_log_ui(void)
         lv_obj_set_style_pad_top(lbl, 2, 0);
         lv_obj_set_style_pad_bottom(lbl, 2, 0);
         lv_obj_set_style_radius(lbl, 4, 0);
-        lv_obj_set_style_text_color(lbl,
-            damage_log[idx].delta > 0 ? lv_color_hex(0x4CAF50) : lv_color_hex(0xFF5252), 0);
+        if (damage_log[idx].event_type == LOG_EVT_COUNTER) {
+            const counter_definition_t *definition = get_counter_definition((counter_type_t)damage_log[idx].source);
+            lv_obj_set_style_text_color(lbl,
+                definition != NULL ? lv_color_hex(definition->accent_color) : lv_color_hex(0xFFB74D), 0);
+        } else {
+            lv_obj_set_style_text_color(lbl,
+                damage_log[idx].delta > 0 ? lv_color_hex(0x4CAF50) : lv_color_hex(0xFF5252), 0);
+        }
         lv_obj_set_style_text_font(lbl, &lv_font_montserrat_14, 0);
     }
 

--- a/knobby/knob_damage_log.h
+++ b/knobby/knob_damage_log.h
@@ -9,6 +9,7 @@ typedef enum {
     LOG_EVT_LIFE = 0,
     LOG_EVT_CMD_DAMAGE,
     LOG_EVT_POISON,
+    LOG_EVT_COUNTER,
 } log_event_type_t;
 
 extern lv_obj_t *screen_damage_log;

--- a/knobby/knob_life.c
+++ b/knobby/knob_life.c
@@ -35,8 +35,18 @@ static int damage_start_value = 0;
 int multiplayer_pending_life_delta = 0;
 int multiplayer_preview_player = -1;
 bool multiplayer_life_preview_active = false;
+int multiplayer_counter_values[MAX_PLAYERS][COUNTER_TYPE_COUNT] = {{0}};
+counter_type_t multiplayer_counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
+int multiplayer_counter_edit_value = 0;
 static lv_timer_t *life_preview_timer = NULL;
 static lv_timer_t *multiplayer_life_preview_timer = NULL;
+
+static const counter_definition_t counter_definitions[COUNTER_TYPE_COUNT] = {
+    {"Commander\nTax", "Commander Tax", "C", 0xA84300, true},
+    {"Partner\nTax", "Partner Tax", "P", 0x1565C0, true},
+    {"Poison", "Poison", "!", 0x2E7D32, true},
+    {"Experience", "Experience", "E", 0x6A1B9A, true},
+};
 
 // ---------- player colors ----------
 static const uint32_t player_color_table[MAX_PLAYERS][LIFE_VIB_COUNT] = {
@@ -122,6 +132,63 @@ int get_cmd_target_player_index(int row)
     }
 
     return row;
+}
+
+const counter_definition_t *get_counter_definition(counter_type_t type)
+{
+    if (type < 0 || type >= COUNTER_TYPE_COUNT) return NULL;
+    return &counter_definitions[type];
+}
+
+bool counter_type_is_enabled(counter_type_t type)
+{
+    const counter_definition_t *definition = get_counter_definition(type);
+
+    return (definition != NULL) && definition->enabled;
+}
+
+int get_multiplayer_counter_value(int player, counter_type_t type)
+{
+    if (player < 0 || player >= MAX_PLAYERS) return 0;
+    if (type < 0 || type >= COUNTER_TYPE_COUNT) return 0;
+
+    return multiplayer_counter_values[player][type];
+}
+
+void begin_multiplayer_counter_edit(int player, counter_type_t type)
+{
+    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (type < 0 || type >= COUNTER_TYPE_COUNT) return;
+
+    multiplayer_menu_player = player;
+    multiplayer_counter_edit_type = type;
+    multiplayer_counter_edit_value = multiplayer_counter_values[player][type];
+}
+
+void change_multiplayer_counter_edit(int delta)
+{
+    multiplayer_counter_edit_value = clamp_counter(multiplayer_counter_edit_value + delta);
+}
+
+int apply_multiplayer_counter_edit(void)
+{
+    int player = multiplayer_menu_player;
+    int old_value;
+    int change_delta;
+
+    if (player < 0 || player >= MAX_PLAYERS) return 0;
+    if (multiplayer_counter_edit_type < 0 || multiplayer_counter_edit_type >= COUNTER_TYPE_COUNT) return 0;
+
+    old_value = multiplayer_counter_values[player][multiplayer_counter_edit_type];
+    multiplayer_counter_edit_value = clamp_counter(multiplayer_counter_edit_value);
+    change_delta = multiplayer_counter_edit_value - old_value;
+    multiplayer_counter_values[player][multiplayer_counter_edit_type] = multiplayer_counter_edit_value;
+
+    if (change_delta != 0) {
+        damage_log_add(player, change_delta, LOG_EVT_COUNTER, multiplayer_counter_edit_type);
+    }
+
+    return change_delta;
 }
 
 // ---------- life preview ----------
@@ -315,6 +382,17 @@ void undo_cmd_damage(int source, int target, int delta)
         multiplayer_cmd_damage_totals[source][target] = 0;
 }
 
+void undo_counter_change(int player, int counter_type, int delta)
+{
+    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (counter_type < 0 || counter_type >= COUNTER_TYPE_COUNT) return;
+
+    multiplayer_counter_values[player][counter_type] = clamp_counter(
+        multiplayer_counter_values[player][counter_type] - delta
+    );
+    refresh_multiplayer_ui();
+}
+
 // ---------- reset ----------
 void knob_life_reset(void)
 {
@@ -347,7 +425,10 @@ void knob_life_reset(void)
     multiplayer_menu_player = 0;
     cmd_damage_target = -1;
     memset(multiplayer_cmd_damage_totals, 0, sizeof(multiplayer_cmd_damage_totals));
+    memset(multiplayer_counter_values, 0, sizeof(multiplayer_counter_values));
     multiplayer_all_damage_value = 0;
+    multiplayer_counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
+    multiplayer_counter_edit_value = 0;
 
     if (life_preview_timer != NULL) {
         lv_timer_pause(life_preview_timer);
@@ -372,6 +453,9 @@ void knob_life_init(void)
     for (i = 0; i < MAX_PLAYERS; i++) {
         multiplayer_life[i] = starting_life;
     }
+    memset(multiplayer_counter_values, 0, sizeof(multiplayer_counter_values));
+    multiplayer_counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
+    multiplayer_counter_edit_value = 0;
 
     life_preview_timer = lv_timer_create(life_preview_commit_cb, 3000, NULL);
     if (life_preview_timer != NULL) {

--- a/knobby/knob_life.h
+++ b/knobby/knob_life.h
@@ -3,6 +3,22 @@
 
 #include "knob_types.h"
 
+typedef enum {
+	COUNTER_TYPE_COMMANDER_TAX = 0,
+	COUNTER_TYPE_PARTNER_TAX,
+	COUNTER_TYPE_POISON,
+	COUNTER_TYPE_EXPERIENCE,
+	COUNTER_TYPE_COUNT,
+} counter_type_t;
+
+typedef struct {
+	const char *menu_label;
+	const char *display_name;
+	const char *badge_text;
+	uint32_t accent_color;
+	bool enabled;
+} counter_definition_t;
+
 // ---------- state ----------
 extern int active_enemy_count;
 extern int life_total;
@@ -21,6 +37,9 @@ extern int multiplayer_pending_life_delta;
 extern int multiplayer_preview_player;
 extern bool multiplayer_life_preview_active;
 extern int dice_result;
+extern int multiplayer_counter_values[MAX_PLAYERS][COUNTER_TYPE_COUNT];
+extern counter_type_t multiplayer_counter_edit_type;
+extern int multiplayer_counter_edit_value;
 
 // ---------- functions ----------
 void knob_life_init(void);
@@ -34,8 +53,15 @@ void change_multiplayer_life(int delta);
 void change_multiplayer_all_damage(int delta);
 void undo_life_change(int player, int delta);
 void undo_cmd_damage(int source, int target, int delta);
+void undo_counter_change(int player, int counter_type, int delta);
 void prepare_cmd_damage_for_player(int target);
 void multiplayer_life_preview_commit_cb(lv_timer_t *timer);
+void begin_multiplayer_counter_edit(int player, counter_type_t type);
+void change_multiplayer_counter_edit(int delta);
+int apply_multiplayer_counter_edit(void);
+int get_multiplayer_counter_value(int player, counter_type_t type);
+const counter_definition_t *get_counter_definition(counter_type_t type);
+bool counter_type_is_enabled(counter_type_t type);
 
 // ---------- player colors ----------
 lv_color_t get_player_color_vib(int index, int vibrancy);

--- a/knobby/knob_scr_multiplayer.c
+++ b/knobby/knob_scr_multiplayer.c
@@ -12,6 +12,8 @@ lv_obj_t *screen_2p = NULL;
 lv_obj_t *screen_3p = NULL;
 lv_obj_t *screen_player_menu = NULL;
 lv_obj_t *screen_player_all_damage = NULL;
+lv_obj_t *screen_player_counters_menu = NULL;
+lv_obj_t *screen_player_counter_edit = NULL;
 
 // ---------- widgets ----------
 static lv_obj_t *multiplayer_quadrants[MULTIPLAYER_COUNT];
@@ -20,11 +22,18 @@ static lv_obj_t *label_multiplayer_name[MULTIPLAYER_COUNT];
 static lv_obj_t *label_multiplayer_all_damage_title = NULL;
 static lv_obj_t *label_multiplayer_all_damage_value = NULL;
 static lv_obj_t *label_multiplayer_all_damage_hint = NULL;
+static lv_obj_t *label_multiplayer_counter_edit_title = NULL;
+static lv_obj_t *label_multiplayer_counter_edit_value = NULL;
+static lv_obj_t *label_multiplayer_counter_edit_hint = NULL;
+static lv_obj_t *counter_row_4p[MULTIPLAYER_COUNT][COUNTER_TYPE_COUNT];
+static lv_obj_t *counter_value_4p[MULTIPLAYER_COUNT][COUNTER_TYPE_COUNT];
 
 // ---------- 2-player widgets ----------
 static lv_obj_t *mp2_panels[2];
 static lv_obj_t *label_mp2_life[2];
 static lv_obj_t *label_mp2_name[2];
+static lv_obj_t *counter_row_2p[2][COUNTER_TYPE_COUNT];
+static lv_obj_t *counter_value_2p[2][COUNTER_TYPE_COUNT];
 
 // ---------- selection auto-deselect ----------
 static lv_timer_t *select_timeout_timer = NULL;
@@ -33,34 +42,103 @@ static lv_timer_t *select_timeout_timer = NULL;
 static lv_obj_t *mp3_panels[3];
 static lv_obj_t *label_mp3_life[3];
 static lv_obj_t *label_mp3_name[3];
+static lv_obj_t *counter_row_3p[3][COUNTER_TYPE_COUNT];
+static lv_obj_t *counter_value_3p[3][COUNTER_TYPE_COUNT];
 
 // ---------- forward declarations ----------
 static void open_multiplayer_all_damage_screen(void);
+static void open_multiplayer_counter_edit_screen(counter_type_t type);
+
+static void apply_object_rotation(lv_obj_t *obj, int16_t angle, int pivot_x, int pivot_y)
+{
+    if (obj == NULL) return;
+
+    lv_obj_set_style_transform_angle(obj, angle, 0);
+    if (angle != 0) {
+        lv_obj_update_layout(obj);
+        lv_obj_set_style_transform_pivot_x(obj,
+            lv_obj_get_width(obj) / 2 + pivot_x, 0);
+        lv_obj_set_style_transform_pivot_y(obj,
+            lv_obj_get_height(obj) / 2 + pivot_y, 0);
+    }
+}
+
+static void create_counter_row(lv_obj_t *parent, counter_type_t type,
+                               lv_obj_t **row_out, lv_obj_t **value_out)
+{
+    const counter_definition_t *definition = get_counter_definition(type);
+    lv_obj_t *row;
+    lv_obj_t *icon;
+    lv_obj_t *glyph;
+
+    row = make_plain_box(parent, 34, 34);
+    lv_obj_add_flag(row, LV_OBJ_FLAG_HIDDEN);
+
+    icon = lv_obj_create(row);
+    lv_obj_remove_style_all(icon);
+    lv_obj_set_size(icon, 16, 16);
+    lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_radius(icon, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_opa(icon, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(icon,
+        definition != NULL ? lv_color_hex(definition->accent_color) : lv_color_hex(0x303030), 0);
+
+    glyph = lv_label_create(icon);
+    lv_label_set_text(glyph, definition != NULL ? definition->badge_text : "?");
+    lv_obj_set_style_text_color(glyph, lv_color_white(), 0);
+    lv_obj_set_style_text_font(glyph, &lv_font_montserrat_14, 0);
+    lv_obj_center(glyph);
+
+    *value_out = lv_label_create(row);
+    lv_label_set_text(*value_out, "0");
+    lv_obj_set_style_text_color(*value_out, lv_color_white(), 0);
+    lv_obj_set_style_text_font(*value_out, &lv_font_montserrat_14, 0);
+    lv_obj_align(*value_out, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_text_align(*value_out, LV_TEXT_ALIGN_CENTER, 0);
+
+    *row_out = row;
+}
 
 // ---------- rotation helper ----------
 static void apply_label_rotation(lv_obj_t *life_lbl, lv_obj_t *name_lbl,
                                   int16_t angle, int life_pivot_y, int name_pivot_y)
 {
-    if (life_lbl != NULL) {
-        lv_obj_set_style_transform_angle(life_lbl, angle, 0);
-        if (angle != 0) {
-            lv_obj_update_layout(life_lbl);
-            lv_obj_set_style_transform_pivot_x(life_lbl,
-                lv_obj_get_width(life_lbl) / 2, 0);
-            lv_obj_set_style_transform_pivot_y(life_lbl,
-                lv_obj_get_height(life_lbl) / 2 + life_pivot_y, 0);
-        }
-    }
-    if (name_lbl != NULL) {
-        lv_obj_set_style_transform_angle(name_lbl, angle, 0);
-        if (angle != 0) {
-            lv_obj_update_layout(name_lbl);
-            lv_obj_set_style_transform_pivot_x(name_lbl,
-                lv_obj_get_width(name_lbl) / 2, 0);
-            lv_obj_set_style_transform_pivot_y(name_lbl,
-                lv_obj_get_height(name_lbl) / 2 + name_pivot_y, 0);
-        }
-    }
+    apply_object_rotation(life_lbl, angle, 0, life_pivot_y);
+    apply_object_rotation(name_lbl, angle, 0, name_pivot_y);
+}
+
+static void get_counter_equator_anchor(lv_obj_t *panel,
+                                       lv_coord_t *anchor_x, lv_coord_t *anchor_y)
+{
+    lv_obj_t *parent;
+    lv_coord_t panel_y;
+    lv_coord_t panel_h;
+    lv_coord_t parent_h;
+    lv_coord_t panel_center_y;
+    lv_coord_t target_world_y;
+    const lv_coord_t equator_gap = 24;
+    const lv_coord_t edge_margin = 24;
+
+    if (anchor_x == NULL || anchor_y == NULL) return;
+
+    *anchor_x = 0;
+    *anchor_y = 0;
+    if (panel == NULL) return;
+
+    parent = lv_obj_get_parent(panel);
+    if (parent == NULL) return;
+
+    panel_y = lv_obj_get_y(panel);
+    panel_h = lv_obj_get_height(panel);
+    parent_h = lv_obj_get_height(parent);
+    panel_center_y = panel_y + (panel_h / 2);
+
+    target_world_y = (parent_h / 2) + ((panel_center_y < (parent_h / 2)) ? -equator_gap : equator_gap);
+    if (target_world_y < panel_y + edge_margin) target_world_y = panel_y + edge_margin;
+    if (target_world_y > panel_y + panel_h - edge_margin) target_world_y = panel_y + panel_h - edge_margin;
+
+    *anchor_x = 0;
+    *anchor_y = target_world_y - panel_center_y;
 }
 
 static int16_t get_4p_orientation_angle(int mode, int panel_index)
@@ -91,8 +169,74 @@ static int16_t get_3p_orientation_angle(int mode, int panel_index)
     }
 }
 
+static int16_t get_counter_row_angle(int orientation_mode, lv_obj_t *panel, int16_t panel_angle)
+{
+    if (orientation_mode == ORIENTATION_MODE_CENTRIC) {
+        lv_obj_t *parent;
+
+        if (panel == NULL) return 0;
+
+        parent = lv_obj_get_parent(panel);
+        if (parent == NULL) return 0;
+
+        if ((lv_obj_get_y(panel) + (lv_obj_get_height(panel) / 2)) < (lv_obj_get_height(parent) / 2)) {
+            return 1800;
+        }
+
+        return 0;
+    }
+
+    return panel_angle;
+}
+
 // ---------- refresh helpers ----------
-static void refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t *name_lbl, int i, int color_i)
+static void refresh_counter_rows(lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **value_labels,
+                                 int player_index, lv_color_t text_color,
+                                 int16_t panel_angle, int16_t row_angle)
+{
+    int type;
+    int visible_count = 0;
+    int visible_types[COUNTER_TYPE_COUNT];
+    char buf[8];
+    const lv_coord_t step = 30;
+    lv_coord_t anchor_x = 0;
+    lv_coord_t anchor_y = 0;
+
+    (void)panel_angle;
+    get_counter_equator_anchor(panel, &anchor_x, &anchor_y);
+
+    for (type = 0; type < COUNTER_TYPE_COUNT; type++) {
+        if (rows[type] == NULL || value_labels[type] == NULL) continue;
+
+        if (!counter_type_is_enabled((counter_type_t)type) ||
+            get_multiplayer_counter_value(player_index, (counter_type_t)type) <= 0) {
+            lv_obj_add_flag(rows[type], LV_OBJ_FLAG_HIDDEN);
+            continue;
+        }
+
+        visible_types[visible_count] = type;
+        visible_count++;
+    }
+
+    for (type = 0; type < visible_count; type++) {
+        int value;
+        int counter_type = visible_types[type];
+        lv_coord_t x_offset = (lv_coord_t)((type * step) - ((visible_count - 1) * step / 2));
+        lv_coord_t local_x = anchor_x + x_offset;
+        lv_coord_t local_y = anchor_y;
+
+        value = get_multiplayer_counter_value(player_index, (counter_type_t)counter_type);
+
+        snprintf(buf, sizeof(buf), "%d", value);
+        lv_label_set_text(value_labels[counter_type], buf);
+        lv_obj_set_style_text_color(value_labels[counter_type], text_color, 0);
+        lv_obj_clear_flag(rows[counter_type], LV_OBJ_FLAG_HIDDEN);
+        lv_obj_align(rows[counter_type], LV_ALIGN_CENTER, local_x, local_y);
+        apply_object_rotation(rows[counter_type], row_angle, 0, 0);
+    }
+}
+
+static lv_color_t refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t *name_lbl, int i, int color_i)
 {
     char buf[8];
     bool preview_here = multiplayer_life_preview_active && (multiplayer_preview_player == i);
@@ -150,6 +294,8 @@ static void refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t *name
         lv_label_set_text(name_lbl, multiplayer_names[i]);
         lv_obj_set_style_text_color(name_lbl, text_color, 0);
     }
+
+    return text_color;
 }
 
 static void refresh_multiplayer_4p_ui(void)
@@ -157,10 +303,13 @@ static void refresh_multiplayer_4p_ui(void)
     int orientation_mode = nvs_get_orientation();
     int i;
     int16_t angle;
+    int16_t counter_angle;
+    lv_color_t text_color;
 
     for (i = 0; i < MULTIPLAYER_COUNT; i++) {
         angle = get_4p_orientation_angle(orientation_mode, i);
-        refresh_mp_panel(multiplayer_quadrants[i], label_multiplayer_life[i], label_multiplayer_name[i], i, i);
+        counter_angle = get_counter_row_angle(orientation_mode, multiplayer_quadrants[i], angle);
+        text_color = refresh_mp_panel(multiplayer_quadrants[i], label_multiplayer_life[i], label_multiplayer_name[i], i, i);
         if (label_multiplayer_life[i] != NULL) {
             lv_obj_clear_flag(label_multiplayer_life[i], LV_OBJ_FLAG_HIDDEN);
             lv_obj_align(label_multiplayer_life[i], LV_ALIGN_CENTER, 0, angle != 0 ? -30 : -12);
@@ -171,6 +320,7 @@ static void refresh_multiplayer_4p_ui(void)
         }
         apply_label_rotation(label_multiplayer_life[i], label_multiplayer_name[i],
             angle, 30, -30);
+        refresh_counter_rows(multiplayer_quadrants[i], counter_row_4p[i], counter_value_4p[i], i, text_color, angle, counter_angle);
     }
 }
 
@@ -181,11 +331,16 @@ static void refresh_multiplayer_2p_ui(void)
     static const int panel_color[2]  = {0, 1};
     int orientation_mode = nvs_get_orientation();
     int i;
+    int16_t angle;
+    lv_color_t text_color;
     for (i = 0; i < 2; i++) {
-        refresh_mp_panel(mp2_panels[i], label_mp2_life[i], label_mp2_name[i],
+        angle = (i == 0 && orientation_mode != ORIENTATION_MODE_ABSOLUTE) ? 1800 : 0;
+        text_color = refresh_mp_panel(mp2_panels[i], label_mp2_life[i], label_mp2_name[i],
                          panel_player[i], panel_color[i]);
         apply_label_rotation(label_mp2_life[i], label_mp2_name[i],
-            (i == 0 && orientation_mode != ORIENTATION_MODE_ABSOLUTE) ? 1800 : 0, 10, -30);
+            angle, 10, -30);
+        refresh_counter_rows(mp2_panels[i], counter_row_2p[i], counter_value_2p[i], panel_player[i],
+            text_color, angle, get_counter_row_angle(orientation_mode, mp2_panels[i], angle));
     }
 }
 
@@ -196,10 +351,13 @@ static void refresh_multiplayer_3p_ui(void)
     int orientation_mode = nvs_get_orientation();
     int i;
     int16_t angle;
+    int16_t counter_angle;
+    lv_color_t text_color;
 
     for (i = 0; i < 3; i++) {
         angle = get_3p_orientation_angle(orientation_mode, i);
-        refresh_mp_panel(mp3_panels[i], label_mp3_life[i], label_mp3_name[i],
+        counter_angle = get_counter_row_angle(orientation_mode, mp3_panels[i], angle);
+        text_color = refresh_mp_panel(mp3_panels[i], label_mp3_life[i], label_mp3_name[i],
                          panel_player[i], panel_player[i]);
         if (label_mp3_life[i] != NULL)
             lv_obj_align(label_mp3_life[i], LV_ALIGN_CENTER, 0, angle != 0 ? -30 : -12);
@@ -207,6 +365,7 @@ static void refresh_multiplayer_3p_ui(void)
             lv_obj_align(label_mp3_name[i], LV_ALIGN_CENTER, 0, 30);
         apply_label_rotation(label_mp3_life[i], label_mp3_name[i],
             angle, 30, -30);
+        refresh_counter_rows(mp3_panels[i], counter_row_3p[i], counter_value_3p[i], panel_player[i], text_color, angle, counter_angle);
     }
 }
 
@@ -233,6 +392,26 @@ void refresh_multiplayer_all_damage_ui(void)
     }
 }
 
+void refresh_multiplayer_counter_edit_ui(void)
+{
+    char title_buf[48];
+    char value_buf[16];
+    const counter_definition_t *definition = get_counter_definition(multiplayer_counter_edit_type);
+
+    if (definition == NULL) return;
+
+    if (label_multiplayer_counter_edit_title != NULL) {
+        snprintf(title_buf, sizeof(title_buf), "%s\n%s",
+            multiplayer_names[multiplayer_menu_player], definition->display_name);
+        lv_label_set_text(label_multiplayer_counter_edit_title, title_buf);
+    }
+
+    if (label_multiplayer_counter_edit_value != NULL) {
+        snprintf(value_buf, sizeof(value_buf), "%d", multiplayer_counter_edit_value);
+        lv_label_set_text(label_multiplayer_counter_edit_value, value_buf);
+    }
+}
+
 // ---------- navigation ----------
 void open_multiplayer_screen(void)
 {
@@ -249,11 +428,23 @@ void open_multiplayer_menu_screen(int player_index)
     load_screen_if_needed(screen_player_menu);
 }
 
+void open_multiplayer_counter_menu_screen(void)
+{
+    load_screen_if_needed(screen_player_counters_menu);
+}
+
 static void open_multiplayer_all_damage_screen(void)
 {
     multiplayer_all_damage_value = 0;
     refresh_multiplayer_all_damage_ui();
     load_screen_if_needed(screen_player_all_damage);
+}
+
+static void open_multiplayer_counter_edit_screen(counter_type_t type)
+{
+    begin_multiplayer_counter_edit(multiplayer_menu_player, type);
+    refresh_multiplayer_counter_edit_ui();
+    load_screen_if_needed(screen_player_counter_edit);
 }
 
 // ---------- quadrant-to-player mapping ----------
@@ -354,6 +545,36 @@ static void event_multiplayer_menu_all_damage(lv_event_t *e)
     open_multiplayer_all_damage_screen();
 }
 
+static void event_multiplayer_menu_counters(lv_event_t *e)
+{
+    (void)e;
+    open_multiplayer_counter_menu_screen();
+}
+
+static void event_multiplayer_counter_commander_tax(lv_event_t *e)
+{
+    (void)e;
+    open_multiplayer_counter_edit_screen(COUNTER_TYPE_COMMANDER_TAX);
+}
+
+static void event_multiplayer_counter_partner_tax(lv_event_t *e)
+{
+    (void)e;
+    open_multiplayer_counter_edit_screen(COUNTER_TYPE_PARTNER_TAX);
+}
+
+static void event_multiplayer_counter_poison(lv_event_t *e)
+{
+    (void)e;
+    open_multiplayer_counter_edit_screen(COUNTER_TYPE_POISON);
+}
+
+static void event_multiplayer_counter_experience(lv_event_t *e)
+{
+    (void)e;
+    open_multiplayer_counter_edit_screen(COUNTER_TYPE_EXPERIENCE);
+}
+
 static void event_multiplayer_all_damage_apply(lv_event_t *e)
 {
     int i;
@@ -364,6 +585,15 @@ static void event_multiplayer_all_damage_apply(lv_event_t *e)
         multiplayer_life[i] = clamp_life(multiplayer_life[i] - multiplayer_all_damage_value);
     }
 
+    refresh_multiplayer_ui();
+    open_multiplayer_screen();
+}
+
+static void event_multiplayer_counter_apply(lv_event_t *e)
+{
+    (void)e;
+    apply_multiplayer_counter_edit();
+    refresh_multiplayer_counter_edit_ui();
     refresh_multiplayer_ui();
     open_multiplayer_screen();
 }
@@ -408,6 +638,19 @@ void build_multiplayer_screen(void)
         lv_obj_set_style_text_font(label_multiplayer_life[i], &lv_font_montserrat_32, 0);
         lv_obj_align(label_multiplayer_life[i], LV_ALIGN_CENTER, 0, -30);
 
+        create_counter_row(multiplayer_quadrants[i], COUNTER_TYPE_COMMANDER_TAX,
+            &counter_row_4p[i][COUNTER_TYPE_COMMANDER_TAX],
+            &counter_value_4p[i][COUNTER_TYPE_COMMANDER_TAX]);
+        create_counter_row(multiplayer_quadrants[i], COUNTER_TYPE_PARTNER_TAX,
+            &counter_row_4p[i][COUNTER_TYPE_PARTNER_TAX],
+            &counter_value_4p[i][COUNTER_TYPE_PARTNER_TAX]);
+        create_counter_row(multiplayer_quadrants[i], COUNTER_TYPE_POISON,
+            &counter_row_4p[i][COUNTER_TYPE_POISON],
+            &counter_value_4p[i][COUNTER_TYPE_POISON]);
+        create_counter_row(multiplayer_quadrants[i], COUNTER_TYPE_EXPERIENCE,
+            &counter_row_4p[i][COUNTER_TYPE_EXPERIENCE],
+            &counter_value_4p[i][COUNTER_TYPE_EXPERIENCE]);
+
     }
 
     refresh_multiplayer_ui();
@@ -419,13 +662,25 @@ void build_multiplayer_menu_screen(void)
         {"Rename",      event_multiplayer_menu_rename,     true,  LV_EVENT_CLICKED},
         {"Cmd\nDamage", event_multiplayer_menu_cmd_damage, true,  LV_EVENT_CLICKED},
         {"All\nDamage", event_multiplayer_menu_all_damage, true,  LV_EVENT_CLICKED},
-        {"",            NULL,                              false, LV_EVENT_CLICKED},
+        {"Counters",    event_multiplayer_menu_counters,   true,  LV_EVENT_CLICKED},
     };
     build_quad_screen(&screen_player_menu, items);
 
     /* Long-press Rename to rename all players sequentially */
     lv_obj_t *rename_btn = lv_obj_get_child(screen_player_menu, 0);
     lv_obj_add_event_cb(rename_btn, event_multiplayer_menu_rename_all, LV_EVENT_LONG_PRESSED, NULL);
+}
+
+void build_multiplayer_counter_menu_screen(void)
+{
+    quad_item_t items[4] = {
+        {"Commander\nTax", event_multiplayer_counter_commander_tax, true, LV_EVENT_CLICKED},
+        {"Partner\nTax", event_multiplayer_counter_partner_tax, true, LV_EVENT_CLICKED},
+        {"Poison", event_multiplayer_counter_poison, true, LV_EVENT_CLICKED},
+        {"Experience", event_multiplayer_counter_experience, true, LV_EVENT_CLICKED},
+    };
+
+    build_quad_screen(&screen_player_counters_menu, items);
 }
 
 void build_multiplayer_all_damage_screen(void)
@@ -453,6 +708,39 @@ void build_multiplayer_all_damage_screen(void)
     lv_obj_align(label_multiplayer_all_damage_hint, LV_ALIGN_CENTER, 0, 38);
 
     lv_obj_t *btn = make_button(screen_player_all_damage, "apply", 120, 46, event_multiplayer_all_damage_apply);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
+}
+
+void build_multiplayer_counter_edit_screen(void)
+{
+    lv_obj_t *btn;
+
+    screen_player_counter_edit = lv_obj_create(NULL);
+    lv_obj_set_size(screen_player_counter_edit, 360, 360);
+    lv_obj_set_style_bg_color(screen_player_counter_edit, lv_color_black(), 0);
+    lv_obj_set_style_border_width(screen_player_counter_edit, 0, 0);
+    lv_obj_set_scrollbar_mode(screen_player_counter_edit, LV_SCROLLBAR_MODE_OFF);
+
+    label_multiplayer_counter_edit_title = lv_label_create(screen_player_counter_edit);
+    lv_label_set_text(label_multiplayer_counter_edit_title, "P1\nCommander Tax");
+    lv_obj_set_style_text_color(label_multiplayer_counter_edit_title, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_multiplayer_counter_edit_title, &lv_font_montserrat_22, 0);
+    lv_obj_set_style_text_align(label_multiplayer_counter_edit_title, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(label_multiplayer_counter_edit_title, LV_ALIGN_TOP_MID, 0, 42);
+
+    label_multiplayer_counter_edit_value = lv_label_create(screen_player_counter_edit);
+    lv_label_set_text(label_multiplayer_counter_edit_value, "0");
+    lv_obj_set_style_text_color(label_multiplayer_counter_edit_value, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_multiplayer_counter_edit_value, &lv_font_montserrat_32, 0);
+    lv_obj_align(label_multiplayer_counter_edit_value, LV_ALIGN_CENTER, 0, -4);
+
+    label_multiplayer_counter_edit_hint = lv_label_create(screen_player_counter_edit);
+    lv_label_set_text(label_multiplayer_counter_edit_hint, "Turn knob, then apply");
+    lv_obj_set_style_text_color(label_multiplayer_counter_edit_hint, lv_color_hex(0x7A7A7A), 0);
+    lv_obj_set_style_text_font(label_multiplayer_counter_edit_hint, &lv_font_montserrat_14, 0);
+    lv_obj_align(label_multiplayer_counter_edit_hint, LV_ALIGN_CENTER, 0, 34);
+
+    btn = make_button(screen_player_counter_edit, "apply", 120, 46, event_multiplayer_counter_apply);
     lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
 }
 
@@ -495,6 +783,19 @@ void build_multiplayer_2p_screen(void)
         lv_obj_set_style_text_color(label_mp2_life[i], lv_color_white(), 0);
         lv_obj_set_style_text_font(label_mp2_life[i], &lv_font_montserrat_32, 0);
         lv_obj_align(label_mp2_life[i], LV_ALIGN_CENTER, 0, -10);
+
+        create_counter_row(mp2_panels[i], COUNTER_TYPE_COMMANDER_TAX,
+            &counter_row_2p[i][COUNTER_TYPE_COMMANDER_TAX],
+            &counter_value_2p[i][COUNTER_TYPE_COMMANDER_TAX]);
+        create_counter_row(mp2_panels[i], COUNTER_TYPE_PARTNER_TAX,
+            &counter_row_2p[i][COUNTER_TYPE_PARTNER_TAX],
+            &counter_value_2p[i][COUNTER_TYPE_PARTNER_TAX]);
+        create_counter_row(mp2_panels[i], COUNTER_TYPE_POISON,
+            &counter_row_2p[i][COUNTER_TYPE_POISON],
+            &counter_value_2p[i][COUNTER_TYPE_POISON]);
+        create_counter_row(mp2_panels[i], COUNTER_TYPE_EXPERIENCE,
+            &counter_row_2p[i][COUNTER_TYPE_EXPERIENCE],
+            &counter_value_2p[i][COUNTER_TYPE_EXPERIENCE]);
 
     }
 }
@@ -541,5 +842,18 @@ void build_multiplayer_3p_screen(void)
         lv_obj_set_style_text_color(label_mp3_life[i], lv_color_white(), 0);
         lv_obj_set_style_text_font(label_mp3_life[i], &lv_font_montserrat_32, 0);
         lv_obj_align(label_mp3_life[i], LV_ALIGN_CENTER, 0, -12);
+
+        create_counter_row(mp3_panels[i], COUNTER_TYPE_COMMANDER_TAX,
+            &counter_row_3p[i][COUNTER_TYPE_COMMANDER_TAX],
+            &counter_value_3p[i][COUNTER_TYPE_COMMANDER_TAX]);
+        create_counter_row(mp3_panels[i], COUNTER_TYPE_PARTNER_TAX,
+            &counter_row_3p[i][COUNTER_TYPE_PARTNER_TAX],
+            &counter_value_3p[i][COUNTER_TYPE_PARTNER_TAX]);
+        create_counter_row(mp3_panels[i], COUNTER_TYPE_POISON,
+            &counter_row_3p[i][COUNTER_TYPE_POISON],
+            &counter_value_3p[i][COUNTER_TYPE_POISON]);
+        create_counter_row(mp3_panels[i], COUNTER_TYPE_EXPERIENCE,
+            &counter_row_3p[i][COUNTER_TYPE_EXPERIENCE],
+            &counter_value_3p[i][COUNTER_TYPE_EXPERIENCE]);
     }
 }

--- a/knobby/knob_scr_multiplayer.h
+++ b/knobby/knob_scr_multiplayer.h
@@ -9,6 +9,8 @@ extern lv_obj_t *screen_2p;
 extern lv_obj_t *screen_3p;
 extern lv_obj_t *screen_player_menu;
 extern lv_obj_t *screen_player_all_damage;
+extern lv_obj_t *screen_player_counters_menu;
+extern lv_obj_t *screen_player_counter_edit;
 
 // ---------- functions ----------
 void build_multiplayer_screen(void);
@@ -16,12 +18,16 @@ void build_multiplayer_2p_screen(void);
 void build_multiplayer_3p_screen(void);
 void build_multiplayer_menu_screen(void);
 void build_multiplayer_all_damage_screen(void);
+void build_multiplayer_counter_menu_screen(void);
+void build_multiplayer_counter_edit_screen(void);
 
 void refresh_multiplayer_ui(void);
 void refresh_multiplayer_all_damage_ui(void);
+void refresh_multiplayer_counter_edit_ui(void);
 
 void open_multiplayer_screen(void);
 void open_multiplayer_menu_screen(int player_index);
+void open_multiplayer_counter_menu_screen(void);
 void select_kick_timer(void);
 
 #endif // _KNOB_SCR_MULTIPLAYER_H

--- a/knobby/knob_types.h
+++ b/knobby/knob_types.h
@@ -11,6 +11,8 @@
 #define MAX_PLAYERS 4
 #define LIFE_MIN -999
 #define LIFE_MAX 999
+#define COUNTER_MIN 0
+#define COUNTER_MAX 9999
 #define DEFAULT_LIFE_TOTAL 40
 #define DEFAULT_BRIGHTNESS_PERCENT 30
 #define INTRO_CHAR_COUNT 7
@@ -90,6 +92,13 @@ static inline int clamp_brightness(int value)
 {
     if (value < 1) return 1;
     if (value > 100) return 100;
+    return value;
+}
+
+static inline int clamp_counter(int value)
+{
+    if (value < COUNTER_MIN) return COUNTER_MIN;
+    if (value > COUNTER_MAX) return COUNTER_MAX;
     return value;
 }
 

--- a/knobby/lv_conf.h
+++ b/knobby/lv_conf.h
@@ -49,7 +49,7 @@
 #define LV_MEM_CUSTOM 0
 #if LV_MEM_CUSTOM == 0
     /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (64U * 1024U)          /*[bytes]*/
+    #define LV_MEM_SIZE (96U * 1024U)          /*[bytes]*/
 
     /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
     #define LV_MEM_ADR 0     /*0: unused*/


### PR DESCRIPTION
* add support for limited set of player counters. Commander tax, partner tax, poison, and experience.
* added via players long press menu
* displayed along centre of screen in main screen

Closes #3 