### PR TITLE
Feedback improvements

### DIFF
--- a/knobby/knob_scr_main.c
+++ b/knobby/knob_scr_main.c
@@ -423,9 +423,14 @@ static void event_select_enemy(lv_event_t *e)
 static void event_damage_apply(lv_event_t *e)
 {
     (void)e;
+    bool was_cmd = (cmd_damage_target >= 0);
     damage_apply();
-    refresh_select_ui();
-    load_screen_if_needed(screen_select);
+    if (was_cmd) {
+        back_to_main();
+    } else {
+        refresh_select_ui();
+        load_screen_if_needed(screen_select);
+    }
 }
 
 static void event_back_main(lv_event_t *e)
@@ -575,6 +580,6 @@ void build_damage_screen(void)
     lv_obj_set_style_text_font(label_damage_hint, &lv_font_montserrat_14, 0);
     lv_obj_align(label_damage_hint, LV_ALIGN_CENTER, 0, 24);
 
-    lv_obj_t *btn = make_button(screen_damage, "apply", 120, 46, event_damage_apply);
+    lv_obj_t *btn = make_button(screen_damage, "Apply", 120, 46, event_damage_apply);
     lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
 }

--- a/knobby/knob_scr_multiplayer.c
+++ b/knobby/knob_scr_multiplayer.c
@@ -666,7 +666,7 @@ void build_multiplayer_menu_screen(void)
 {
     quad_item_t items[4] = {
         {"Rename",      event_multiplayer_menu_rename,     true,  LV_EVENT_CLICKED},
-        {"Cmd\nDamage", event_multiplayer_menu_cmd_damage, true,  LV_EVENT_CLICKED},
+        {"Commander\nDamage", event_multiplayer_menu_cmd_damage, true,  LV_EVENT_CLICKED},
         {"All\nDamage", event_multiplayer_menu_all_damage, true,  LV_EVENT_CLICKED},
         {"Counters",    event_multiplayer_menu_counters,   true,  LV_EVENT_CLICKED},
     };
@@ -713,7 +713,7 @@ void build_multiplayer_all_damage_screen(void)
     lv_obj_set_style_text_font(label_multiplayer_all_damage_hint, &lv_font_montserrat_14, 0);
     lv_obj_align(label_multiplayer_all_damage_hint, LV_ALIGN_CENTER, 0, 38);
 
-    lv_obj_t *btn = make_button(screen_player_all_damage, "apply", 120, 46, event_multiplayer_all_damage_apply);
+    lv_obj_t *btn = make_button(screen_player_all_damage, "Apply", 120, 46, event_multiplayer_all_damage_apply);
     lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
 }
 
@@ -746,7 +746,7 @@ void build_multiplayer_counter_edit_screen(void)
     lv_obj_set_style_text_font(label_multiplayer_counter_edit_hint, &lv_font_montserrat_14, 0);
     lv_obj_align(label_multiplayer_counter_edit_hint, LV_ALIGN_CENTER, 0, 34);
 
-    btn = make_button(screen_player_counter_edit, "apply", 120, 46, event_multiplayer_counter_apply);
+    btn = make_button(screen_player_counter_edit, "Apply", 120, 46, event_multiplayer_counter_apply);
     lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
 }
 

--- a/knobby/knob_scr_multiplayer.c
+++ b/knobby/knob_scr_multiplayer.c
@@ -496,6 +496,12 @@ static void event_multiplayer_select(lv_event_t *e)
     }
 
     if (multiplayer_selected == player) {
+        /* Deselecting the same player: if there's an active preview for
+         * this player, commit it immediately so the altered life total is
+         * shown (same behavior as selecting another player). */
+        if (multiplayer_life_preview_active && multiplayer_preview_player == player) {
+            multiplayer_life_preview_commit_cb(NULL);
+        }
         multiplayer_selected = -1;
     } else {
         multiplayer_selected = player;

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -368,10 +368,11 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
   {
     bool was_dimmed = activity_kick();
     if (was_dimmed) {
-      data->state = LV_INDEV_STATE_RELEASED;
+      // Reset swipe context on wake, but don't discard the touch
       tp_tracking = false;
       tp_swiped = false;
-    } else if (tp_swiped) {
+    }
+    if (tp_swiped) {
       data->state = LV_INDEV_STATE_RELEASED;
     } else {
       data->point.x = point.x;


### PR DESCRIPTION
Allow touch to be registered on wake (so that double press is not required to select a player when screen is dimmed)
When selecting apply from commander damage screen user is taken abck to main screen.
When deselecting apply manually via press then show commited life total immediately

Closes #31 