### PR TITLE
Add support for JC3636K718 board variant

### DIFF
--- a/knobby/board_detect.c
+++ b/knobby/board_detect.c
@@ -1,0 +1,112 @@
+#include "board_detect.h"
+#include "driver/i2c.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <string.h>
+#include <stdio.h>
+
+#define CST816S_ADDR    0x15
+#define I2C_PROBE_PORT  I2C_NUM_0
+
+/* ---- Board configurations ----
+ * To add a new board:
+ *   1. Add a board_pins_t struct below with all pin assignments and mirror flags
+ *      (get these from the manufacturer's pinconfig.h / example code)
+ *   2. Add an extern for it in board_detect.h
+ *   3. Add a pointer to it in the candidates[] array below
+ * Detection probes CST816S touch (addr 0x15) on each candidate's I2C pins.
+ * First board whose touch responds wins, so put the most common board first. */
+
+const board_pins_t board_k518 = {
+    .name       = "JC3636K518",
+    .tft_blk    = 47,  .tft_rst  = 21,  .tft_cs  = 14,  .tft_sck = 13,
+    .tft_sda0   = 15,  .tft_sda1 = 16,  .tft_sda2 = 17, .tft_sda3 = 18,
+    .touch_scl  = 12,  .touch_sda = 11, .touch_int = 9,  .touch_rst = 10,
+    .enc_a      = 8,   .enc_b    = 7,
+    .bat_adc    = 1,
+    .btn        = 0,
+    .mirror_x   = false, .mirror_y = false,
+};
+
+const board_pins_t board_k718 = {
+    .name       = "JC3636K718",
+    .tft_blk    = 21,  .tft_rst  = 17,  .tft_cs  = 12,  .tft_sck = 11,
+    .tft_sda0   = 13,  .tft_sda1 = 14,  .tft_sda2 = 15, .tft_sda3 = 16,
+    .touch_scl  = 10,  .touch_sda = 9,  .touch_int = 7,  .touch_rst = 8,
+    .enc_a      = 2,   .enc_b    = 1,
+    .bat_adc    = 6,
+    .btn        = 0,
+    .mirror_x   = true,  .mirror_y = true,
+};
+
+/* Candidates to probe, in order. First match wins. */
+static const board_pins_t *candidates[] = {
+    &board_k518,
+    &board_k718,
+};
+#define NUM_CANDIDATES (sizeof(candidates) / sizeof(candidates[0]))
+
+const board_pins_t *board = NULL;
+
+/* ---- I2C probe ---- */
+
+static bool probe_touch(const board_pins_t *candidate)
+{
+    int scl = candidate->touch_scl;
+    int sda = candidate->touch_sda;
+    int rst = candidate->touch_rst;
+    bool found = false;
+
+    /* Toggle reset to wake CST816S — it won't respond to I2C without this */
+    gpio_set_direction((gpio_num_t)rst, GPIO_MODE_OUTPUT);
+    gpio_set_level((gpio_num_t)rst, 0);
+    vTaskDelay(pdMS_TO_TICKS(20));
+    gpio_set_level((gpio_num_t)rst, 1);
+    vTaskDelay(pdMS_TO_TICKS(50));
+
+    /* Set up temporary I2C master for probe */
+    i2c_config_t conf;
+    memset(&conf, 0, sizeof(conf));
+    conf.mode = I2C_MODE_MASTER;
+    conf.sda_io_num = sda;
+    conf.scl_io_num = scl;
+    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.master.clk_speed = 100000;
+
+    if (i2c_param_config(I2C_PROBE_PORT, &conf) == ESP_OK &&
+        i2c_driver_install(I2C_PROBE_PORT, I2C_MODE_MASTER, 0, 0, 0) == ESP_OK) {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (CST816S_ADDR << 1) | I2C_MASTER_WRITE, true);
+        i2c_master_stop(cmd);
+        found = (i2c_master_cmd_begin(I2C_PROBE_PORT, cmd, pdMS_TO_TICKS(100)) == ESP_OK);
+        i2c_cmd_link_delete(cmd);
+        i2c_driver_delete(I2C_PROBE_PORT);
+    }
+
+    /* Reset probed pins so they don't interfere with later init */
+    gpio_reset_pin((gpio_num_t)scl);
+    gpio_reset_pin((gpio_num_t)sda);
+    gpio_reset_pin((gpio_num_t)rst);
+
+    return found;
+}
+
+void board_detect(void)
+{
+    for (size_t i = 0; i < NUM_CANDIDATES; i++) {
+        printf("Probing %s... ", candidates[i]->name);
+        if (probe_touch(candidates[i])) {
+            printf("found!\n");
+            board = candidates[i];
+            return;
+        }
+        printf("no\n");
+    }
+
+    /* Fallback to first candidate */
+    printf("No board detected, defaulting to %s\n", candidates[0]->name);
+    board = candidates[0];
+}

--- a/knobby/board_detect.h
+++ b/knobby/board_detect.h
@@ -1,0 +1,54 @@
+#ifndef _BOARD_DETECT_H
+#define _BOARD_DETECT_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *name;
+    /* TFT QSPI */
+    int tft_blk;
+    int tft_rst;
+    int tft_cs;
+    int tft_sck;
+    int tft_sda0;
+    int tft_sda1;
+    int tft_sda2;
+    int tft_sda3;
+    /* Touch I2C */
+    int touch_scl;
+    int touch_sda;
+    int touch_int;
+    int touch_rst;
+    /* Rotary encoder */
+    int enc_a;
+    int enc_b;
+    /* Battery ADC */
+    int bat_adc;
+    /* Button */
+    int btn;
+    /* Display orientation */
+    bool mirror_x;
+    bool mirror_y;
+} board_pins_t;
+
+/* Global pointer to detected board config. Set by board_detect(),
+ * must be called before any pin-dependent init. */
+extern const board_pins_t *board;
+
+/* Known board configurations */
+extern const board_pins_t board_k518;
+extern const board_pins_t board_k718;
+
+/* Probe I2C touch controllers to identify which board we're on.
+ * Falls back to K518 if detection fails. */
+void board_detect(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BOARD_DETECT_H */

--- a/knobby/knob_hw.c
+++ b/knobby/knob_hw.c
@@ -3,7 +3,8 @@
 #include "driver/ledc.h"
 
 // ---------- private constants ----------
-#define BACKLIGHT_PIN 47
+#include "pincfg.h"
+#define BACKLIGHT_PIN TFT_BLK
 #define BACKLIGHT_LEDC_MODE LEDC_LOW_SPEED_MODE
 #define BACKLIGHT_LEDC_TIMER LEDC_TIMER_0
 #define BACKLIGHT_LEDC_CHANNEL LEDC_CHANNEL_0

--- a/knobby/knob_nvs.c
+++ b/knobby/knob_nvs.c
@@ -18,7 +18,11 @@ static char cached_name_list[NAME_LIST_COUNT][NAME_LIST_LEN];
 // ---------- init ----------
 void knob_nvs_init(void)
 {
-    nvs_flash_init();
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        nvs_flash_erase();
+        nvs_flash_init();
+    }
 
     nvs_handle_t handle;
     if (nvs_open("knobby", NVS_READONLY, &handle) == ESP_OK) {

--- a/knobby/knobby.ino
+++ b/knobby/knobby.ino
@@ -10,7 +10,7 @@
 #include "knob.h"
 #include "knob_hw.h"
 
-static const int BATTERY_ADC_PIN = 1;
+static const int BATTERY_ADC_PIN = BATTERY_ADC_PIN_NUM;
 static const float BATTERY_DIVIDER_RATIO = 2.0f;
 static const float BATTERY_CALIBRATION_SCALE = 1.0f;
 static const float BATTERY_CALIBRATION_OFFSET = 0.0f;

--- a/knobby/knobby.ino
+++ b/knobby/knobby.ino
@@ -4,13 +4,13 @@
 #include "driver/gpio.h"
 #include "soc/usb_serial_jtag_struct.h"
 
+#include "board_detect.h"
 #include "scr_st77916.h"
 #include <lvgl.h>
 #include "hal/lv_hal.h"
 #include "knob.h"
 #include "knob_hw.h"
 
-static const int BATTERY_ADC_PIN = BATTERY_ADC_PIN_NUM;
 static const float BATTERY_DIVIDER_RATIO = 2.0f;
 static const float BATTERY_CALIBRATION_SCALE = 1.0f;
 static const float BATTERY_CALIBRATION_OFFSET = 0.0f;
@@ -26,9 +26,9 @@ extern "C" float knob_read_battery_voltage(void)
   const int sample_count = 16;
   float measured_voltage = 0.0f;
 
-  analogSetPinAttenuation(BATTERY_ADC_PIN, ADC_11db);
+  analogSetPinAttenuation(BATTERY_ADC_PIN_NUM, ADC_11db);
   for (int i = 0; i < sample_count; i++) {
-    uint32_t sample = analogReadMilliVolts(BATTERY_ADC_PIN);
+    uint32_t sample = analogReadMilliVolts(BATTERY_ADC_PIN_NUM);
     sum += sample;
     if (sample < min_sample) min_sample = sample;
     if (sample > max_sample) max_sample = sample;
@@ -57,6 +57,9 @@ extern "C" float knob_read_battery_voltage(void)
 
 void setup()
 {
+  // Detect which board we're running on before any pin-dependent init
+  board_detect();
+
   // Use the configured active CPU frequency for easier tuning.
   setCpuFrequencyMhz(CPU_FREQ_ACTIVE);
 

--- a/knobby/pincfg.h
+++ b/knobby/pincfg.h
@@ -1,8 +1,46 @@
 #ifndef _PINCFG_H_
 #define _PINCFG_H_
 
-#define TFT_BLK 47
+// Board selection: define exactly one
+#define BOARD_JC3636K518
+// #define BOARD_JC3636K718
 
+#if defined(BOARD_JC3636K718)
+
+#define TFT_BLK 21
+#define TFT_RST 17
+#define TFT_CS 12
+#define TFT_SCK 11
+#define TFT_SDA0 13
+#define TFT_SDA1 14
+#define TFT_SDA2 15
+#define TFT_SDA3 16
+
+#define TOUCH_PIN_NUM_I2C_SCL 10
+#define TOUCH_PIN_NUM_I2C_SDA 9
+#define TOUCH_PIN_NUM_INT 7
+#define TOUCH_PIN_NUM_RST 8
+
+#define ROTARY_ENC_PIN_A 2
+#define ROTARY_ENC_PIN_B 1
+
+#define BATTERY_ADC_PIN_NUM 6
+
+#define BTN_PIN 0
+
+#define PIN_LCD_TE 18
+
+#define AUDIO_I2S_BCK_IO 3
+#define AUDIO_I2S_WS_IO 45
+#define AUDIO_I2S_DO_IO 42
+#define AUDIO_MUTE_PIN 46
+
+#define MIC_I2S_SCK 5
+#define MIC_I2S_SD 4
+
+#elif defined(BOARD_JC3636K518)
+
+#define TFT_BLK 47
 #define TFT_RST 21
 #define TFT_CS 14
 #define TFT_SCK 13
@@ -10,10 +48,6 @@
 #define TFT_SDA1 16
 #define TFT_SDA2 17
 #define TFT_SDA3 18
-#define BTN_PIN 0
-
-
-#define BTN_PIN 0
 
 #define TOUCH_PIN_NUM_I2C_SCL 12
 #define TOUCH_PIN_NUM_I2C_SDA 11
@@ -23,21 +57,22 @@
 #define ROTARY_ENC_PIN_A 8
 #define ROTARY_ENC_PIN_B 7
 
-#define SD_MMC_D0_PIN 15
-#define SD_MMC_D1_PIN 16
-#define SD_MMC_D2_PIN 17
-#define SD_MMC_D3_PIN 18
-#define SD_MMC_CLK_PIN 13
-#define SD_MMC_CMD_PIN 14
+#define BATTERY_ADC_PIN_NUM 1
 
-#define AUDIO_I2S_MCK_IO -1 // MCK
-#define AUDIO_I2S_BCK_IO 18 // BCK
-#define AUDIO_I2S_WS_IO 16  // LCK
-#define AUDIO_I2S_DO_IO 17  // DIN
-#define AUDIO_MUTE_PIN 48   // 低电平静音
+#define BTN_PIN 0
+
+#define AUDIO_I2S_MCK_IO -1
+#define AUDIO_I2S_BCK_IO 18
+#define AUDIO_I2S_WS_IO 16
+#define AUDIO_I2S_DO_IO 17
+#define AUDIO_MUTE_PIN 48
 
 #define MIC_I2S_WS 45
 #define MIC_I2S_SD 46
 #define MIC_I2S_SCK 42
+
+#else
+#error "No board selected in pincfg.h — define BOARD_JC3636K518 or BOARD_JC3636K718"
+#endif
 
 #endif

--- a/knobby/pincfg.h
+++ b/knobby/pincfg.h
@@ -1,78 +1,30 @@
 #ifndef _PINCFG_H_
 #define _PINCFG_H_
 
-// Board selection: define exactly one
-#define BOARD_JC3636K518
-// #define BOARD_JC3636K718
+#include "board_detect.h"
 
-#if defined(BOARD_JC3636K718)
+/* Compatibility macros — all pin references resolve through the
+ * runtime-detected board pointer set by board_detect(). */
 
-#define TFT_BLK 21
-#define TFT_RST 17
-#define TFT_CS 12
-#define TFT_SCK 11
-#define TFT_SDA0 13
-#define TFT_SDA1 14
-#define TFT_SDA2 15
-#define TFT_SDA3 16
+#define TFT_BLK               (board->tft_blk)
+#define TFT_RST               (board->tft_rst)
+#define TFT_CS                (board->tft_cs)
+#define TFT_SCK               (board->tft_sck)
+#define TFT_SDA0              (board->tft_sda0)
+#define TFT_SDA1              (board->tft_sda1)
+#define TFT_SDA2              (board->tft_sda2)
+#define TFT_SDA3              (board->tft_sda3)
 
-#define TOUCH_PIN_NUM_I2C_SCL 10
-#define TOUCH_PIN_NUM_I2C_SDA 9
-#define TOUCH_PIN_NUM_INT 7
-#define TOUCH_PIN_NUM_RST 8
+#define TOUCH_PIN_NUM_I2C_SCL (board->touch_scl)
+#define TOUCH_PIN_NUM_I2C_SDA (board->touch_sda)
+#define TOUCH_PIN_NUM_INT     (board->touch_int)
+#define TOUCH_PIN_NUM_RST     (board->touch_rst)
 
-#define ROTARY_ENC_PIN_A 2
-#define ROTARY_ENC_PIN_B 1
+#define ROTARY_ENC_PIN_A      (board->enc_a)
+#define ROTARY_ENC_PIN_B      (board->enc_b)
 
-#define BATTERY_ADC_PIN_NUM 6
+#define BATTERY_ADC_PIN_NUM   (board->bat_adc)
 
-#define BTN_PIN 0
+#define BTN_PIN               (board->btn)
 
-#define PIN_LCD_TE 18
-
-#define AUDIO_I2S_BCK_IO 3
-#define AUDIO_I2S_WS_IO 45
-#define AUDIO_I2S_DO_IO 42
-#define AUDIO_MUTE_PIN 46
-
-#define MIC_I2S_SCK 5
-#define MIC_I2S_SD 4
-
-#elif defined(BOARD_JC3636K518)
-
-#define TFT_BLK 47
-#define TFT_RST 21
-#define TFT_CS 14
-#define TFT_SCK 13
-#define TFT_SDA0 15
-#define TFT_SDA1 16
-#define TFT_SDA2 17
-#define TFT_SDA3 18
-
-#define TOUCH_PIN_NUM_I2C_SCL 12
-#define TOUCH_PIN_NUM_I2C_SDA 11
-#define TOUCH_PIN_NUM_INT 9
-#define TOUCH_PIN_NUM_RST 10
-
-#define ROTARY_ENC_PIN_A 8
-#define ROTARY_ENC_PIN_B 7
-
-#define BATTERY_ADC_PIN_NUM 1
-
-#define BTN_PIN 0
-
-#define AUDIO_I2S_MCK_IO -1
-#define AUDIO_I2S_BCK_IO 18
-#define AUDIO_I2S_WS_IO 16
-#define AUDIO_I2S_DO_IO 17
-#define AUDIO_MUTE_PIN 48
-
-#define MIC_I2S_WS 45
-#define MIC_I2S_SD 46
-#define MIC_I2S_SCK 42
-
-#else
-#error "No board selected in pincfg.h — define BOARD_JC3636K518 or BOARD_JC3636K718"
-#endif
-
-#endif
+#endif /* _PINCFG_H_ */

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -229,6 +229,7 @@ const esp_lcd_panel_vendor_init_cmd_t lcd_init_cmd[] = {
     {0x29, (uint8_t[]){0x00}, 1, 0}
 };
 
+
 #define TFT_SPI_FREQ_HZ (50 * 1000 * 1000)
 
 static void my_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p)
@@ -533,7 +534,12 @@ void scr_lvgl_init()
   lcd->begin();
 
   lcd->invertColor(true);
-  // setRotation(0);  //设置屏幕方向
+#if defined(BOARD_JC3636K718)
+  lcd->mirrorX(true);
+  lcd->mirrorY(true);
+  touch->mirrorX(true);
+  touch->mirrorY(true);
+#endif
   lcd->displayOn();
 
   screen_switch(true);

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -31,16 +31,12 @@ int encoder_cont = 0;
 static volatile bool touch_irq_pending = false;
 #define USE_CUSTOM_INIT_CMD 0 // 是否用自定义的初始化代码
 
-#if TOUCH_PIN_NUM_INT >= 0
-
 IRAM_ATTR bool onTouchInterruptCallback(void *user_data)
 {
   (void)user_data;
   touch_irq_pending = true;
   return false;
 }
-
-#endif
 
 const esp_lcd_panel_vendor_init_cmd_t lcd_init_cmd[] = {
      {0xF0, (uint8_t[]){0x28}, 1, 0},
@@ -518,9 +514,9 @@ void scr_lvgl_init()
   touch->init();
   touch->begin();
 
-#if TOUCH_PIN_NUM_INT >= 0
-  touch->attachInterruptCallback(onTouchInterruptCallback, NULL);
-#endif
+  if (TOUCH_PIN_NUM_INT >= 0) {
+    touch->attachInterruptCallback(onTouchInterruptCallback, NULL);
+  }
 
   ESP_PanelBusQSPI *panel_bus = new ESP_PanelBusQSPI(TFT_CS, TFT_SCK, TFT_SDA0, TFT_SDA1, TFT_SDA2, TFT_SDA3);
   panel_bus->configQspiFreqHz(TFT_SPI_FREQ_HZ);
@@ -534,12 +530,14 @@ void scr_lvgl_init()
   lcd->begin();
 
   lcd->invertColor(true);
-#if defined(BOARD_JC3636K718)
-  lcd->mirrorX(true);
-  lcd->mirrorY(true);
-  touch->mirrorX(true);
-  touch->mirrorY(true);
-#endif
+  if (board->mirror_x) {
+    lcd->mirrorX(true);
+    touch->mirrorX(true);
+  }
+  if (board->mirror_y) {
+    lcd->mirrorY(true);
+    touch->mirrorY(true);
+  }
   lcd->displayOn();
 
   screen_switch(true);


### PR DESCRIPTION
* Make NVS init safer for new boards
* Add support for JC3636K718 board variant
* Automatically detect and choose board during startup