### PR TITLE
Add counter support to the 1 player screen

### DIFF
--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -99,7 +99,11 @@ static void handle_back_navigation(lv_obj_t *screen)
         if (!name_screen_handle_back())
             open_multiplayer_menu_screen(multiplayer_menu_player);
     } else if (screen == screen_player_counters_menu) {
-        open_multiplayer_menu_screen(multiplayer_menu_player);
+        if (counter_edit_is_singleplayer) {
+            back_to_main();
+        } else {
+            open_multiplayer_menu_screen(multiplayer_menu_player);
+        }
     } else if (screen == screen_player_counter_edit) {
         open_multiplayer_counter_menu_screen();
     } else if (screen == screen_player_all_damage) {

--- a/knobby/knob_life.c
+++ b/knobby/knob_life.c
@@ -38,6 +38,8 @@ bool multiplayer_life_preview_active = false;
 int multiplayer_counter_values[MAX_PLAYERS][COUNTER_TYPE_COUNT] = {{0}};
 counter_type_t multiplayer_counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
 int multiplayer_counter_edit_value = 0;
+int singleplayer_counter_values[COUNTER_TYPE_COUNT] = {0};
+bool counter_edit_is_singleplayer = false;
 static lv_timer_t *life_preview_timer = NULL;
 static lv_timer_t *multiplayer_life_preview_timer = NULL;
 
@@ -160,6 +162,7 @@ void begin_multiplayer_counter_edit(int player, counter_type_t type)
     if (player < 0 || player >= MAX_PLAYERS) return;
     if (type < 0 || type >= COUNTER_TYPE_COUNT) return;
 
+    counter_edit_is_singleplayer = false;
     multiplayer_menu_player = player;
     multiplayer_counter_edit_type = type;
     multiplayer_counter_edit_value = multiplayer_counter_values[player][type];
@@ -186,6 +189,40 @@ int apply_multiplayer_counter_edit(void)
 
     if (change_delta != 0) {
         damage_log_add(player, change_delta, LOG_EVT_COUNTER, multiplayer_counter_edit_type);
+    }
+
+    return change_delta;
+}
+
+int get_singleplayer_counter_value(counter_type_t type)
+{
+    if (type < 0 || type >= COUNTER_TYPE_COUNT) return 0;
+    return singleplayer_counter_values[type];
+}
+
+void begin_singleplayer_counter_edit(counter_type_t type)
+{
+    if (type < 0 || type >= COUNTER_TYPE_COUNT) return;
+
+    counter_edit_is_singleplayer = true;
+    multiplayer_counter_edit_type = type;
+    multiplayer_counter_edit_value = singleplayer_counter_values[type];
+}
+
+int apply_singleplayer_counter_edit(void)
+{
+    int old_value;
+    int change_delta;
+
+    if (multiplayer_counter_edit_type < 0 || multiplayer_counter_edit_type >= COUNTER_TYPE_COUNT) return 0;
+
+    old_value = singleplayer_counter_values[multiplayer_counter_edit_type];
+    multiplayer_counter_edit_value = clamp_counter(multiplayer_counter_edit_value);
+    change_delta = multiplayer_counter_edit_value - old_value;
+    singleplayer_counter_values[multiplayer_counter_edit_type] = multiplayer_counter_edit_value;
+
+    if (change_delta != 0) {
+        damage_log_add(-1, change_delta, LOG_EVT_COUNTER, multiplayer_counter_edit_type);
     }
 
     return change_delta;
@@ -384,13 +421,19 @@ void undo_cmd_damage(int source, int target, int delta)
 
 void undo_counter_change(int player, int counter_type, int delta)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
     if (counter_type < 0 || counter_type >= COUNTER_TYPE_COUNT) return;
 
-    multiplayer_counter_values[player][counter_type] = clamp_counter(
-        multiplayer_counter_values[player][counter_type] - delta
-    );
-    refresh_multiplayer_ui();
+    if (player < 0) {
+        singleplayer_counter_values[counter_type] = clamp_counter(
+            singleplayer_counter_values[counter_type] - delta
+        );
+        refresh_main_ui();
+    } else if (player < MAX_PLAYERS) {
+        multiplayer_counter_values[player][counter_type] = clamp_counter(
+            multiplayer_counter_values[player][counter_type] - delta
+        );
+        refresh_multiplayer_ui();
+    }
 }
 
 // ---------- reset ----------
@@ -426,9 +469,11 @@ void knob_life_reset(void)
     cmd_damage_target = -1;
     memset(multiplayer_cmd_damage_totals, 0, sizeof(multiplayer_cmd_damage_totals));
     memset(multiplayer_counter_values, 0, sizeof(multiplayer_counter_values));
+    memset(singleplayer_counter_values, 0, sizeof(singleplayer_counter_values));
     multiplayer_all_damage_value = 0;
     multiplayer_counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
     multiplayer_counter_edit_value = 0;
+    counter_edit_is_singleplayer = false;
 
     if (life_preview_timer != NULL) {
         lv_timer_pause(life_preview_timer);
@@ -454,8 +499,10 @@ void knob_life_init(void)
         multiplayer_life[i] = starting_life;
     }
     memset(multiplayer_counter_values, 0, sizeof(multiplayer_counter_values));
+    memset(singleplayer_counter_values, 0, sizeof(singleplayer_counter_values));
     multiplayer_counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
     multiplayer_counter_edit_value = 0;
+    counter_edit_is_singleplayer = false;
 
     life_preview_timer = lv_timer_create(life_preview_commit_cb, 3000, NULL);
     if (life_preview_timer != NULL) {

--- a/knobby/knob_life.h
+++ b/knobby/knob_life.h
@@ -40,6 +40,8 @@ extern int dice_result;
 extern int multiplayer_counter_values[MAX_PLAYERS][COUNTER_TYPE_COUNT];
 extern counter_type_t multiplayer_counter_edit_type;
 extern int multiplayer_counter_edit_value;
+extern int singleplayer_counter_values[COUNTER_TYPE_COUNT];
+extern bool counter_edit_is_singleplayer;
 
 // ---------- functions ----------
 void knob_life_init(void);
@@ -60,6 +62,9 @@ void begin_multiplayer_counter_edit(int player, counter_type_t type);
 void change_multiplayer_counter_edit(int delta);
 int apply_multiplayer_counter_edit(void);
 int get_multiplayer_counter_value(int player, counter_type_t type);
+void begin_singleplayer_counter_edit(counter_type_t type);
+int apply_singleplayer_counter_edit(void);
+int get_singleplayer_counter_value(counter_type_t type);
 const counter_definition_t *get_counter_definition(counter_type_t type);
 bool counter_type_is_enabled(counter_type_t type);
 

--- a/knobby/knob_scr_main.c
+++ b/knobby/knob_scr_main.c
@@ -19,7 +19,6 @@ static lv_obj_t *label_life_total = NULL;
 static lv_obj_t *label_life_preview_total = NULL;
 static lv_obj_t *turn_container = NULL;
 static lv_obj_t *label_turn = NULL;
-static lv_obj_t *label_turn_time = NULL;
 static lv_obj_t *turn_live_dot = NULL;
 
 // ---------- select UI ----------
@@ -52,22 +51,23 @@ static void refresh_ring(void)
 
 void refresh_turn_ui(void)
 {
-    char turn_buf[24];
-    char time_buf[24];
+    char buf[48];
     uint32_t total_seconds = get_turn_elapsed_ms() / 1000;
     uint32_t hours = total_seconds / 3600;
     uint32_t minutes = (total_seconds % 3600) / 60;
 
     if (turn_number <= 0) {
-        lv_label_set_text(label_turn, "turn");
+        snprintf(buf, sizeof(buf), "turn  %lu:%02lu",
+                 (unsigned long)hours, (unsigned long)minutes);
     } else {
-        snprintf(turn_buf, sizeof(turn_buf), "turn %d", turn_number);
-        lv_label_set_text(label_turn, turn_buf);
+        snprintf(buf, sizeof(buf), "turn %d  %lu:%02lu",
+                 turn_number, (unsigned long)hours, (unsigned long)minutes);
     }
+    lv_label_set_text(label_turn, buf);
 
-    snprintf(time_buf, sizeof(time_buf), "%lu:%02lu",
-             (unsigned long)hours, (unsigned long)minutes);
-    lv_label_set_text(label_turn_time, time_buf);
+    if (turn_live_dot != NULL) {
+        lv_obj_align_to(turn_live_dot, label_turn, LV_ALIGN_OUT_RIGHT_MID, 6, 0);
+    }
 
     if (turn_container != NULL) {
         if (turn_ui_visible) {
@@ -295,31 +295,25 @@ void build_main_screen(void)
     lv_obj_align(label_life_preview_total, LV_ALIGN_CENTER, 0, 80);
     lv_obj_add_flag(label_life_preview_total, LV_OBJ_FLAG_HIDDEN);
 
-    turn_container = make_plain_box(screen_1p, 96, 96);
-    lv_obj_align(turn_container, LV_ALIGN_CENTER, 110, -6);
+    turn_container = make_plain_box(screen_1p, 240, 32);
+    lv_obj_align(turn_container, LV_ALIGN_CENTER, 0, 120);
     lv_obj_add_flag(turn_container, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_flag(turn_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_event_cb(turn_container, event_turn_tap, LV_EVENT_CLICKED, NULL);
 
     label_turn = lv_label_create(turn_container);
-    lv_label_set_text(label_turn, "turn");
-    lv_obj_set_style_text_color(label_turn, lv_color_white(), 0);
+    lv_label_set_text(label_turn, "turn  0:00");
+    lv_obj_set_style_text_color(label_turn, lv_color_hex(0xB8B8B8), 0);
     lv_obj_set_style_text_font(label_turn, &lv_font_montserrat_22, 0);
-    lv_obj_align(label_turn, LV_ALIGN_TOP_MID, 0, 10);
-
-    label_turn_time = lv_label_create(turn_container);
-    lv_label_set_text(label_turn_time, "0:00");
-    lv_obj_set_style_text_color(label_turn_time, lv_color_hex(0xB8B8B8), 0);
-    lv_obj_set_style_text_font(label_turn_time, &lv_font_montserrat_22, 0);
-    lv_obj_align(label_turn_time, LV_ALIGN_TOP_MID, -8, 48);
+    lv_obj_align(label_turn, LV_ALIGN_CENTER, 0, 0);
 
     turn_live_dot = lv_obj_create(turn_container);
     lv_obj_remove_style_all(turn_live_dot);
-    lv_obj_set_size(turn_live_dot, 12, 12);
+    lv_obj_set_size(turn_live_dot, 10, 10);
     lv_obj_set_style_radius(turn_live_dot, LV_RADIUS_CIRCLE, 0);
     lv_obj_set_style_bg_color(turn_live_dot, lv_palette_main(LV_PALETTE_RED), 0);
     lv_obj_set_style_bg_opa(turn_live_dot, LV_OPA_COVER, 0);
-    lv_obj_align(turn_live_dot, LV_ALIGN_TOP_MID, 28, 52);
+    lv_obj_align_to(turn_live_dot, label_turn, LV_ALIGN_OUT_RIGHT_MID, 6, 0);
     lv_obj_add_flag(turn_live_dot, LV_OBJ_FLAG_HIDDEN);
 }
 

--- a/knobby/knob_scr_main.c
+++ b/knobby/knob_scr_main.c
@@ -1,11 +1,11 @@
 #include "knob_scr_main.h"
+#include "knob_scr_multiplayer.h"
 #include "knob_life.h"
 #include "knob_timer.h"
 #include "knob_nvs.h"
 
 // Forward declarations for multiplayer routing
 extern lv_obj_t *screen_4p;
-extern void refresh_multiplayer_ui(void);
 
 // ---------- screens ----------
 lv_obj_t *screen_1p = NULL;
@@ -20,6 +20,11 @@ static lv_obj_t *label_life_preview_total = NULL;
 static lv_obj_t *turn_container = NULL;
 static lv_obj_t *label_turn = NULL;
 static lv_obj_t *turn_live_dot = NULL;
+
+// ---------- 1p counter widgets ----------
+static lv_obj_t *counter_row_1p[COUNTER_TYPE_COUNT];
+static lv_obj_t *counter_value_1p[COUNTER_TYPE_COUNT];
+static lv_obj_t *counter_hitbox = NULL;
 
 // ---------- select UI ----------
 static lv_obj_t *label_select_title = NULL;
@@ -123,11 +128,58 @@ static void refresh_life_digits(void)
     }
 }
 
+static void refresh_1p_counters(void)
+{
+    int type;
+    int visible_count = 0;
+    int visible_types[COUNTER_TYPE_COUNT];
+    char buf[8];
+    const lv_coord_t step = 30;
+    const lv_coord_t counter_y = 46;
+    lv_color_t text_color = lv_color_white();
+
+    for (type = 0; type < COUNTER_TYPE_COUNT; type++) {
+        if (counter_row_1p[type] == NULL || counter_value_1p[type] == NULL) continue;
+
+        if (!counter_type_is_enabled((counter_type_t)type) ||
+            get_singleplayer_counter_value((counter_type_t)type) <= 0) {
+            lv_obj_add_flag(counter_row_1p[type], LV_OBJ_FLAG_HIDDEN);
+            continue;
+        }
+
+        visible_types[visible_count] = type;
+        visible_count++;
+    }
+
+    for (type = 0; type < visible_count; type++) {
+        int value;
+        int counter_type = visible_types[type];
+        lv_coord_t x_offset = (lv_coord_t)((type * step) - ((visible_count - 1) * step / 2));
+
+        value = get_singleplayer_counter_value((counter_type_t)counter_type);
+
+        snprintf(buf, sizeof(buf), "%d", value);
+        lv_label_set_text(counter_value_1p[counter_type], buf);
+        lv_obj_set_style_text_color(counter_value_1p[counter_type], text_color, 0);
+        lv_obj_clear_flag(counter_row_1p[counter_type], LV_OBJ_FLAG_HIDDEN);
+        lv_obj_align(counter_row_1p[counter_type], LV_ALIGN_TOP_MID, x_offset, counter_y);
+    }
+
+    if (counter_hitbox != NULL) {
+        if (visible_count > 0) {
+            lv_obj_clear_flag(counter_hitbox, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(counter_hitbox, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+}
+
 void refresh_main_ui(void)
 {
     refresh_ring();
     refresh_life_digits();
     refresh_turn_ui();
+    refresh_1p_counters();
 }
 
 void refresh_select_ui(void)
@@ -213,6 +265,12 @@ void open_select_screen(void)
     load_screen_if_needed(screen_select);
 }
 
+void open_1p_counter_menu_screen(void)
+{
+    counter_edit_is_singleplayer = true;
+    open_multiplayer_counter_menu_screen();
+}
+
 static void open_damage_screen(int enemy_index)
 {
     selected_enemy = enemy_index;
@@ -227,6 +285,12 @@ static void event_open_select(lv_event_t *e)
     (void)e;
     if (active_enemy_count <= 0) return;
     open_select_screen();
+}
+
+static void event_open_1p_counters(lv_event_t *e)
+{
+    (void)e;
+    open_1p_counter_menu_screen();
 }
 
 static void event_select_enemy(lv_event_t *e)
@@ -252,6 +316,43 @@ static void event_back_main(lv_event_t *e)
 {
     (void)e;
     back_to_main();
+}
+
+// ---------- counter row helper ----------
+static void create_counter_row_1p(lv_obj_t *parent, counter_type_t type,
+                                  lv_obj_t **row_out, lv_obj_t **value_out)
+{
+    const counter_definition_t *definition = get_counter_definition(type);
+    lv_obj_t *row;
+    lv_obj_t *icon;
+    lv_obj_t *glyph;
+
+    row = make_plain_box(parent, 34, 34);
+    lv_obj_add_flag(row, LV_OBJ_FLAG_HIDDEN);
+
+    icon = lv_obj_create(row);
+    lv_obj_remove_style_all(icon);
+    lv_obj_set_size(icon, 16, 16);
+    lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_radius(icon, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_opa(icon, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(icon,
+        definition != NULL ? lv_color_hex(definition->accent_color) : lv_color_hex(0x303030), 0);
+
+    glyph = lv_label_create(icon);
+    lv_label_set_text(glyph, definition != NULL ? definition->badge_text : "?");
+    lv_obj_set_style_text_color(glyph, lv_color_white(), 0);
+    lv_obj_set_style_text_font(glyph, &lv_font_montserrat_14, 0);
+    lv_obj_center(glyph);
+
+    *value_out = lv_label_create(row);
+    lv_label_set_text(*value_out, "0");
+    lv_obj_set_style_text_color(*value_out, lv_color_white(), 0);
+    lv_obj_set_style_text_font(*value_out, &lv_font_montserrat_14, 0);
+    lv_obj_align(*value_out, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_text_align(*value_out, LV_TEXT_ALIGN_CENTER, 0);
+
+    *row_out = row;
 }
 
 // ---------- screen builders ----------
@@ -315,6 +416,25 @@ void build_main_screen(void)
     lv_obj_set_style_bg_opa(turn_live_dot, LV_OPA_COVER, 0);
     lv_obj_align_to(turn_live_dot, label_turn, LV_ALIGN_OUT_RIGHT_MID, 6, 0);
     lv_obj_add_flag(turn_live_dot, LV_OBJ_FLAG_HIDDEN);
+
+    create_counter_row_1p(screen_1p, COUNTER_TYPE_COMMANDER_TAX,
+        &counter_row_1p[COUNTER_TYPE_COMMANDER_TAX],
+        &counter_value_1p[COUNTER_TYPE_COMMANDER_TAX]);
+    create_counter_row_1p(screen_1p, COUNTER_TYPE_PARTNER_TAX,
+        &counter_row_1p[COUNTER_TYPE_PARTNER_TAX],
+        &counter_value_1p[COUNTER_TYPE_PARTNER_TAX]);
+    create_counter_row_1p(screen_1p, COUNTER_TYPE_POISON,
+        &counter_row_1p[COUNTER_TYPE_POISON],
+        &counter_value_1p[COUNTER_TYPE_POISON]);
+    create_counter_row_1p(screen_1p, COUNTER_TYPE_EXPERIENCE,
+        &counter_row_1p[COUNTER_TYPE_EXPERIENCE],
+        &counter_value_1p[COUNTER_TYPE_EXPERIENCE]);
+
+    counter_hitbox = make_plain_box(screen_1p, 180, 50);
+    lv_obj_align(counter_hitbox, LV_ALIGN_TOP_MID, 0, 36);
+    lv_obj_add_flag(counter_hitbox, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(counter_hitbox, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_event_cb(counter_hitbox, event_open_1p_counters, LV_EVENT_CLICKED, NULL);
 }
 
 void build_select_screen(void)

--- a/knobby/knob_scr_main.h
+++ b/knobby/knob_scr_main.h
@@ -18,6 +18,7 @@ void refresh_select_ui(void);
 void refresh_damage_ui(void);
 
 void open_select_screen(void);
+void open_1p_counter_menu_screen(void);
 void back_to_main(void);
 
 #endif // _KNOB_SCR_MAIN_H

--- a/knobby/knob_scr_multiplayer.c
+++ b/knobby/knob_scr_multiplayer.c
@@ -440,8 +440,12 @@ void refresh_multiplayer_counter_edit_ui(void)
     if (definition == NULL) return;
 
     if (label_multiplayer_counter_edit_title != NULL) {
-        snprintf(title_buf, sizeof(title_buf), "%s\n%s",
-            multiplayer_names[multiplayer_menu_player], definition->display_name);
+        if (counter_edit_is_singleplayer) {
+            snprintf(title_buf, sizeof(title_buf), "%s", definition->display_name);
+        } else {
+            snprintf(title_buf, sizeof(title_buf), "%s\n%s",
+                multiplayer_names[multiplayer_menu_player], definition->display_name);
+        }
         lv_label_set_text(label_multiplayer_counter_edit_title, title_buf);
     }
 
@@ -481,7 +485,11 @@ static void open_multiplayer_all_damage_screen(void)
 
 static void open_multiplayer_counter_edit_screen(counter_type_t type)
 {
-    begin_multiplayer_counter_edit(multiplayer_menu_player, type);
+    if (counter_edit_is_singleplayer) {
+        begin_singleplayer_counter_edit(type);
+    } else {
+        begin_multiplayer_counter_edit(multiplayer_menu_player, type);
+    }
     refresh_multiplayer_counter_edit_ui();
     load_screen_if_needed(screen_player_counter_edit);
 }
@@ -637,10 +645,17 @@ static void event_multiplayer_all_damage_apply(lv_event_t *e)
 static void event_multiplayer_counter_apply(lv_event_t *e)
 {
     (void)e;
-    apply_multiplayer_counter_edit();
-    refresh_multiplayer_counter_edit_ui();
-    refresh_multiplayer_ui();
-    open_multiplayer_screen();
+    if (counter_edit_is_singleplayer) {
+        apply_singleplayer_counter_edit();
+        refresh_multiplayer_counter_edit_ui();
+        refresh_main_ui();
+        back_to_main();
+    } else {
+        apply_multiplayer_counter_edit();
+        refresh_multiplayer_counter_edit_ui();
+        refresh_multiplayer_ui();
+        open_multiplayer_screen();
+    }
 }
 
 // ---------- screen builders ----------

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -211,7 +211,21 @@ shot "dice_$((RANDOM % 20 + 1)).png" --screen dice --dice $((RANDOM % 20 + 1))
 shot "damage_log_random.png" --screen damage-log --random-log
 
 # ============================================================
-# 19. Intro screen
+# 19. Timer overlay — 1p mode at various life totals
+# ============================================================
+for life in 0 20 40 444; do
+    shot "1p_timer_life${life}.png" --screen 1p --track 1 \
+        --starting-life "$life" --life "$life" \
+        --turn-number $((RANDOM % 31)) --turn-elapsed $((RANDOM % 21600 * 1000))
+done
+
+# Timer with preview delta +444
+shot "1p_timer_preview_p444.png" --screen 1p --track 1 \
+    --preview-delta +444 --preview-player -1 \
+    --turn-number $((RANDOM % 31)) --turn-elapsed $((RANDOM % 21600 * 1000))
+
+# ============================================================
+# 20. Intro screen
 # ============================================================
 shot "intro.png" --screen intro
 
@@ -260,6 +274,7 @@ write_section() {
 SEC_1P_PREV=(); SEC_2P_PREV=(); SEC_3P_PREV=(); SEC_4P_PREV=()
 SEC_LIFE=(); SEC_LIFECOLOR=(); SEC_SELECTED=(); SEC_COUNTERS=()
 SEC_BRIGHT=(); SEC_COUNTER_EDIT=(); SEC_DAMAGE=(); SEC_SETTINGS=()
+SEC_TIMER=()
 SEC_OTHER=()
 
 for f in "${FILES[@]}"; do
@@ -268,6 +283,7 @@ for f in "${FILES[@]}"; do
         2p_*_preview_*)       SEC_2P_PREV+=("$f") ;;
         3p_*_preview_*)       SEC_3P_PREV+=("$f") ;;
         4p_*_preview_*)       SEC_4P_PREV+=("$f") ;;
+        1p_timer_*)           SEC_TIMER+=("$f") ;;
         *_lifecolor_*)        SEC_LIFECOLOR+=("$f") ;;
         *_life[0-9]*)         SEC_LIFE+=("$f") ;;
         *_selected_*)         SEC_SELECTED+=("$f") ;;
@@ -284,6 +300,7 @@ write_section "1-Player Life Preview" "${SEC_1P_PREV[@]}"
 write_section "2-Player Life Preview" "${SEC_2P_PREV[@]}"
 write_section "3-Player Life Preview" "${SEC_3P_PREV[@]}"
 write_section "4-Player Life Preview" "${SEC_4P_PREV[@]}"
+write_section "1-Player Timer Overlay" "${SEC_TIMER[@]}"
 write_section "Life Totals (Player Colors)" "${SEC_LIFE[@]}"
 write_section "Life Totals (Life Colors)" "${SEC_LIFECOLOR[@]}"
 write_section "Selected Player" "${SEC_SELECTED[@]}"

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -110,8 +110,9 @@ for track in 2 3 4; do
 done
 
 # ============================================================
-# 6. Random counters — multiplayer × orientations
+# 6. Random counters — multiplayer × orientations + 1p
 # ============================================================
+shot "1p_counters.png" --screen 1p --random-counters
 for track in 2 3 4; do
     for orient in 0 1 2; do
         orient_name=("absolute" "centric" "tabletop")
@@ -222,7 +223,8 @@ done
 # Timer with preview delta +444
 shot "1p_timer_preview_p444.png" --screen 1p --track 1 \
     --preview-delta +444 --preview-player -1 \
-    --turn-number $((RANDOM % 31)) --turn-elapsed $((RANDOM % 21600 * 1000))
+    --turn-number $((RANDOM % 31)) --turn-elapsed $((RANDOM % 21600 * 1000)) \
+    --random-counters
 
 # ============================================================
 # 20. Intro screen

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -206,6 +206,9 @@ static void print_usage(void)
            "  --battery-voltage <f>  Battery voltage for battery screen (default: 4.0)\n"
            "  --random-counters      Set all player counters to random values 0-99\n"
            "  --random-log           Populate event log with random entries\n"
+           "\nTimer state (1p only):\n"
+           "  --turn-number <n>      Turn number (enables timer display when > 0)\n"
+           "  --turn-elapsed <ms>    Elapsed game time in milliseconds\n"
            "\n  --help, -h             Show this message\n"
            "\nAvailable screens:\n"
            "  main 1p 2p 3p 4p intro menu tools settings-menu settings-more\n"
@@ -299,6 +302,10 @@ int main(int argc, char *argv[])
     int brightness_set = 0;
     int do_random_counters = 0;
     int do_random_log = 0;
+    int turn_number_val = 0;
+    int turn_number_set = 0;
+    uint32_t turn_elapsed_val = 0;
+    int turn_elapsed_set = 0;
     int i;
 
     srand((unsigned int)time(NULL));
@@ -363,6 +370,12 @@ int main(int argc, char *argv[])
             do_random_counters = 1;
         } else if (strcmp(argv[i], "--random-log") == 0) {
             do_random_log = 1;
+        } else if (strcmp(argv[i], "--turn-number") == 0 && i + 1 < argc) {
+            turn_number_val = atoi(argv[++i]);
+            turn_number_set = 1;
+        } else if (strcmp(argv[i], "--turn-elapsed") == 0 && i + 1 < argc) {
+            turn_elapsed_val = (uint32_t)atol(argv[++i]);
+            turn_elapsed_set = 1;
         } else if (strcmp(argv[i], "--outdir") == 0 && i + 1 < argc) {
             outdir = argv[++i];
         } else if (strcmp(argv[i], "--output") == 0 && i + 1 < argc) {
@@ -447,6 +460,16 @@ int main(int argc, char *argv[])
         if (do_random_log) { \
             populate_random_log(); \
             open_damage_log_screen(); \
+        } \
+        if (turn_number_set) { \
+            turn_number = turn_number_val; \
+            turn_timer_enabled = (turn_number_val > 0); \
+            turn_ui_visible = (turn_number_val > 0); \
+            turn_started_ms = lv_tick_get(); \
+            if (turn_elapsed_set) \
+                turn_elapsed_ms = turn_elapsed_val; \
+            else \
+                turn_elapsed_ms = 0; \
         } \
         refresh_main_ui(); \
         lv_obj_update_layout(lv_scr_act()); \

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -251,6 +251,8 @@ static void populate_random_counters(void)
     for (p = 0; p < MAX_PLAYERS; p++)
         for (t = 0; t < COUNTER_TYPE_COUNT; t++)
             multiplayer_counter_values[p][t] = rand() % 100;
+    for (t = 0; t < COUNTER_TYPE_COUNT; t++)
+        singleplayer_counter_values[t] = rand() % 100;
 }
 
 static void populate_random_log(void)


### PR DESCRIPTION
Adds player counters to the 1p screen. Previously counters (commander tax, partner tax, poison, experience) only worked on multiplayer screens. They now display above the life total using the same colored badge style, appearing only when their value is greater than 0.

<img width="360" height="360" alt="1p_counters" src="https://github.com/user-attachments/assets/0ed589e5-0fe1-4335-8c5e-d2f1e4313a0e" />
<img width="360" height="360" alt="1p_timer_preview_p444" src="https://github.com/user-attachments/assets/991dba98-2d50-453c-82ef-76e03670a977" />
