### PR TITLE
Split ui_mp.c into layout code and shared player menus

### DIFF
--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -7,6 +7,7 @@
 #include "src/intro.h"
 #include "src/ui_1p.h"
 #include "src/ui_mp.h"
+#include "src/ui_player_menu.h"
 #include "src/settings.h"
 #include "src/game_mode.h"
 #include "src/damage_log.h"
@@ -97,13 +98,13 @@ static void handle_back_navigation(lv_obj_t *screen)
         back_to_main();
     } else if (screen == screen_player_name) {
         if (!name_screen_handle_back())
-            open_multiplayer_menu_screen(menu_player);
-    } else if (screen == screen_player_counters_menu) {
-        open_multiplayer_menu_screen(menu_player);
-    } else if (screen == screen_player_counter_edit) {
-        open_multiplayer_counter_menu_screen();
+            open_player_menu(menu_player);
+    } else if (screen == screen_counter_menu) {
+        open_player_menu(menu_player);
+    } else if (screen == screen_counter_edit) {
+        open_counter_menu();
     } else if (screen == screen_player_all_damage) {
-        open_multiplayer_menu_screen(menu_player);
+        open_player_menu(menu_player);
     }
 }
 
@@ -124,8 +125,8 @@ void reset_all_values(void)
     refresh_multiplayer_ui();
 
     refresh_rename_ui();
-    refresh_multiplayer_all_damage_ui();
-    refresh_multiplayer_counter_edit_ui();
+    refresh_all_damage_ui();
+    refresh_counter_edit_ui();
 }
 
 void knob_cb(lv_event_t *e)
@@ -147,12 +148,12 @@ void knob_gui(void)
     build_multiplayer_screen();
     build_multiplayer_2p_screen();
     build_multiplayer_3p_screen();
-    build_multiplayer_menu_screen();
+    build_player_menu_screen();
     build_eliminated_player_menu_screen();
     build_rename_screen();
-    build_multiplayer_all_damage_screen();
-    build_multiplayer_counter_menu_screen();
-    build_multiplayer_counter_edit_screen();
+    build_all_damage_screen();
+    build_counter_menu_screen();
+    build_counter_edit_screen();
     build_select_screen();
     build_damage_screen();
     build_settings_screen();
@@ -168,8 +169,8 @@ void knob_gui(void)
     refresh_rename_ui();
     refresh_select_ui();
     refresh_damage_ui();
-    refresh_multiplayer_all_damage_ui();
-    refresh_multiplayer_counter_edit_ui();
+    refresh_all_damage_ui();
+    refresh_counter_edit_ui();
     refresh_settings_ui();
 
     knob_timer_init();
@@ -221,11 +222,11 @@ static void handle_knob_event(knob_event_t k)
         if (k == KNOB_LEFT)      change_custom_life(-1);
         else if (k == KNOB_RIGHT) change_custom_life(+1);
     }
-    else if (lv_scr_act() == screen_player_counter_edit)
+    else if (lv_scr_act() == screen_counter_edit)
     {
         if (k == KNOB_LEFT)      change_counter_edit(-1);
         else if (k == KNOB_RIGHT) change_counter_edit(+1);
-        refresh_multiplayer_counter_edit_ui();
+        refresh_counter_edit_ui();
     }
     else if (lv_scr_act() == screen_damage_log)
     {

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -6,7 +6,7 @@
 extern void refresh_player_ui(void);
 extern void refresh_select_ui(void);
 extern void refresh_damage_ui(void);
-extern void refresh_multiplayer_all_damage_ui(void);
+extern void refresh_all_damage_ui(void);
 extern void select_kick_timer(void);
 
 // ---------- state ----------
@@ -412,7 +412,7 @@ void change_all_damage(int delta)
 {
     all_damage_value += delta;
     if (all_damage_value < 0) all_damage_value = 0;
-    refresh_multiplayer_all_damage_ui();
+    refresh_all_damage_ui();
 }
 
 // ---------- undo ----------

--- a/knobby/src/rename.c
+++ b/knobby/src/rename.c
@@ -1,5 +1,6 @@
 #include "rename.h"
 #include "ui_mp.h"
+#include "ui_player_menu.h"
 #include "ui_1p.h"
 #include "game.h"
 #include "storage.h"
@@ -110,7 +111,7 @@ static void apply_name_and_return(const char *name)
         refresh_rename_ui();
         refresh_select_ui();
         refresh_damage_ui();
-        open_multiplayer_menu_screen(menu_player);
+        open_player_menu(menu_player);
     }
 }
 
@@ -135,7 +136,7 @@ static void event_name_save(lv_event_t *e)
             refresh_rename_ui();
             refresh_select_ui();
             refresh_damage_ui();
-            open_multiplayer_menu_screen(menu_player);
+            open_player_menu(menu_player);
         }
     } else {
         apply_name_and_return(txt);

--- a/knobby/src/ui_1p.c
+++ b/knobby/src/ui_1p.c
@@ -1,6 +1,7 @@
 #include "ui_1p.h"
 #include "settings.h"
 #include "ui_mp.h"
+#include "ui_player_menu.h"
 #include "game.h"
 #include "timer.h"
 #include "storage.h"
@@ -292,7 +293,7 @@ static void open_damage_screen(int enemy_index)
 static void event_open_1p_menu(lv_event_t *e)
 {
     (void)e;
-    open_multiplayer_menu_screen(0);
+    open_player_menu(0);
 }
 
 static void event_select_enemy(lv_event_t *e)

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -1,32 +1,18 @@
 #include "ui_mp.h"
+#include "ui_player_menu.h"
 #include "ui_1p.h"
 #include "game.h"
 #include "storage.h"
-#include "damage_log.h"
-#include "rename.h"
-#include "settings.h"
 
 // ---------- screens ----------
 lv_obj_t *screen_4p = NULL;
 lv_obj_t *screen_2p = NULL;
 lv_obj_t *screen_3p = NULL;
-lv_obj_t *screen_player_menu = NULL;
-lv_obj_t *screen_player_all_damage = NULL;
-lv_obj_t *screen_player_counters_menu = NULL;
-lv_obj_t *screen_player_counter_edit = NULL;
-lv_obj_t *screen_eliminated_player_menu = NULL;
 
 // ---------- widgets ----------
 static lv_obj_t *multiplayer_quadrants[MULTIPLAYER_COUNT];
 static lv_obj_t *label_player_life[MULTIPLAYER_COUNT];
 static lv_obj_t *label_multiplayer_name[MULTIPLAYER_COUNT];
-static lv_obj_t *label_multiplayer_all_damage_title = NULL;
-static lv_obj_t *label_all_damage_value = NULL;
-static lv_obj_t *label_multiplayer_all_damage_hint = NULL;
-static lv_obj_t *label_multiplayer_counter_edit_title = NULL;
-static lv_obj_t *label_counter_edit_value = NULL;
-static lv_obj_t *label_multiplayer_counter_edit_hint = NULL;
-static lv_obj_t *label_multiplayer_counter_edit_icon = NULL;
 static lv_obj_t *counter_row_4p[MULTIPLAYER_COUNT][COUNTER_TYPE_COUNT];
 static lv_obj_t *counter_value_4p[MULTIPLAYER_COUNT][COUNTER_TYPE_COUNT];
 
@@ -46,10 +32,6 @@ static lv_obj_t *label_mp3_life[3];
 static lv_obj_t *label_mp3_name[3];
 static lv_obj_t *counter_row_3p[3][COUNTER_TYPE_COUNT];
 static lv_obj_t *counter_value_3p[3][COUNTER_TYPE_COUNT];
-
-// ---------- forward declarations ----------
-static void open_multiplayer_all_damage_screen(void);
-static void open_multiplayer_counter_edit_screen(counter_type_t type);
 
 static const lv_font_t *get_counter_badge_font(const counter_definition_t *definition)
 {
@@ -443,49 +425,6 @@ void refresh_multiplayer_ui(void)
     refresh_multiplayer_4p_ui();
 }
 
-void refresh_multiplayer_all_damage_ui(void)
-{
-    char buf[32];
-
-    if (label_multiplayer_all_damage_title != NULL) {
-        lv_label_set_text(label_multiplayer_all_damage_title, "All players");
-    }
-
-    if (label_all_damage_value != NULL) {
-        snprintf(buf, sizeof(buf), "Damage: %d", all_damage_value);
-        lv_label_set_text(label_all_damage_value, buf);
-    }
-}
-
-void refresh_multiplayer_counter_edit_ui(void)
-{
-    char title_buf[48];
-    char value_buf[16];
-    const counter_definition_t *definition = get_counter_definition(counter_edit_type);
-
-    if (definition == NULL) return;
-
-    if (label_multiplayer_counter_edit_icon != NULL) {
-        const lv_font_t *icon_font = (counter_edit_type == COUNTER_TYPE_POISON)
-                                      ? &mana_poison_icon_bold_16
-                                      : &mana_counter_icons_16;
-        lv_label_set_text(label_multiplayer_counter_edit_icon,
-            definition->icon_text ? definition->icon_text : "");
-        lv_obj_set_style_text_font(label_multiplayer_counter_edit_icon, icon_font, 0);
-    }
-
-    if (label_multiplayer_counter_edit_title != NULL) {
-        snprintf(title_buf, sizeof(title_buf), "%s\n%s",
-            player_names[menu_player], definition->display_name);
-        lv_label_set_text(label_multiplayer_counter_edit_title, title_buf);
-    }
-
-    if (label_counter_edit_value != NULL) {
-        snprintf(value_buf, sizeof(value_buf), "%d", counter_edit_value);
-        lv_label_set_text(label_counter_edit_value, value_buf);
-    }
-}
-
 // ---------- navigation ----------
 void open_multiplayer_screen(void)
 {
@@ -494,31 +433,6 @@ void open_multiplayer_screen(void)
     if (track == 2) load_screen_if_needed(screen_2p);
     else if (track == 3) load_screen_if_needed(screen_3p);
     else load_screen_if_needed(screen_4p);
-}
-
-void open_multiplayer_menu_screen(int player_index)
-{
-    menu_player = player_index;
-    load_screen_if_needed(screen_player_menu);
-}
-
-void open_multiplayer_counter_menu_screen(void)
-{
-    load_screen_if_needed(screen_player_counters_menu);
-}
-
-static void open_multiplayer_all_damage_screen(void)
-{
-    all_damage_value = 0;
-    refresh_multiplayer_all_damage_ui();
-    load_screen_if_needed(screen_player_all_damage);
-}
-
-static void open_multiplayer_counter_edit_screen(counter_type_t type)
-{
-    begin_counter_edit(menu_player, type);
-    refresh_multiplayer_counter_edit_ui();
-    load_screen_if_needed(screen_player_counter_edit);
 }
 
 // ---------- quadrant-to-player mapping ----------
@@ -603,92 +517,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
 
     selected_player = player;
     refresh_multiplayer_ui();
-    open_multiplayer_menu_screen(selected_player);
-}
-
-static void event_multiplayer_menu_rename(lv_event_t *e)
-{
-    (void)e;
-    open_rename_screen();
-}
-
-static void event_multiplayer_menu_rename_all(lv_event_t *e)
-{
-    (void)e;
-    open_rename_all_screen();
-}
-
-static void event_multiplayer_menu_cmd_damage(lv_event_t *e)
-{
-    (void)e;
-    prepare_cmd_damage_for_player(menu_player);
-    open_select_screen();
-}
-
-static void event_multiplayer_menu_all_damage(lv_event_t *e)
-{
-    (void)e;
-    open_multiplayer_all_damage_screen();
-}
-
-static void event_multiplayer_menu_counters(lv_event_t *e)
-{
-    (void)e;
-    open_multiplayer_counter_menu_screen();
-}
-
-static void event_eliminated_player_menu_undo(lv_event_t *e)
-{
-    (void)e;
-    undo_elimination_action(menu_player);
-    back_to_main();
-}
-
-static void event_multiplayer_counter_commander_tax(lv_event_t *e)
-{
-    (void)e;
-    open_multiplayer_counter_edit_screen(COUNTER_TYPE_COMMANDER_TAX);
-}
-
-static void event_multiplayer_counter_partner_tax(lv_event_t *e)
-{
-    (void)e;
-    open_multiplayer_counter_edit_screen(COUNTER_TYPE_PARTNER_TAX);
-}
-
-static void event_multiplayer_counter_poison(lv_event_t *e)
-{
-    (void)e;
-    open_multiplayer_counter_edit_screen(COUNTER_TYPE_POISON);
-}
-
-static void event_multiplayer_counter_experience(lv_event_t *e)
-{
-    (void)e;
-    open_multiplayer_counter_edit_screen(COUNTER_TYPE_EXPERIENCE);
-}
-
-static void event_multiplayer_all_damage_apply(lv_event_t *e)
-{
-    int i;
-
-    (void)e;
-    for (i = 0; i < nvs_get_players_to_track(); i++) {
-        damage_log_add(i, -all_damage_value, LOG_EVT_LIFE, -1);
-        player_life[i] = clamp_life(player_life[i] - all_damage_value);
-    }
-
-    refresh_player_ui();
-    back_to_main();
-}
-
-static void event_multiplayer_counter_apply(lv_event_t *e)
-{
-    (void)e;
-    apply_counter_edit();
-    refresh_multiplayer_counter_edit_ui();
-    refresh_player_ui();
-    back_to_main();
+    open_player_menu(selected_player);
 }
 
 // ---------- screen builders ----------
@@ -747,145 +576,6 @@ void build_multiplayer_screen(void)
     }
 
     refresh_multiplayer_ui();
-}
-
-void build_multiplayer_menu_screen(void)
-{
-    quad_item_t items[4] = {
-        {"Rename",      event_multiplayer_menu_rename,     true,  LV_EVENT_CLICKED},
-        {"Commander\nDamage", event_multiplayer_menu_cmd_damage, true,  LV_EVENT_CLICKED},
-        {"All\nDamage", event_multiplayer_menu_all_damage, true,  LV_EVENT_CLICKED},
-        {"Counters",    event_multiplayer_menu_counters,   true,  LV_EVENT_CLICKED},
-    };
-    build_quad_screen(&screen_player_menu, items);
-
-    /* Long-press Rename to rename all players sequentially */
-    lv_obj_t *rename_btn = lv_obj_get_child(screen_player_menu, 0);
-    lv_obj_add_event_cb(rename_btn, event_multiplayer_menu_rename_all, LV_EVENT_LONG_PRESSED, NULL);
-}
-
-void build_eliminated_player_menu_screen(void)
-{
-    screen_eliminated_player_menu = lv_obj_create(NULL);
-    lv_obj_set_size(screen_eliminated_player_menu, 360, 360);
-    lv_obj_set_style_bg_color(screen_eliminated_player_menu, lv_color_black(), 0);
-    lv_obj_set_style_border_width(screen_eliminated_player_menu, 0, 0);
-    lv_obj_set_scrollbar_mode(screen_eliminated_player_menu, LV_SCROLLBAR_MODE_OFF);
-
-    lv_obj_t *title = lv_label_create(screen_eliminated_player_menu);
-    lv_label_set_text(title, "Undo elimination");
-    lv_obj_set_style_text_color(title, lv_color_white(), 0);
-    lv_obj_set_style_text_font(title, &lv_font_montserrat_22, 0);
-    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 40);
-
-    lv_obj_t *hint = lv_label_create(screen_eliminated_player_menu);
-    lv_label_set_text(hint, "Restore the action that eliminated this player");
-    lv_obj_set_style_text_color(hint, lv_color_hex(0x7A7A7A), 0);
-    lv_obj_set_style_text_font(hint, &lv_font_montserrat_14, 0);
-    lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(hint, LV_ALIGN_CENTER, 0, 0);
-
-    lv_obj_t *btn = make_button(screen_eliminated_player_menu, "Undo", 120, 46, event_eliminated_player_menu_undo);
-    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
-}
-
-void build_multiplayer_counter_menu_screen(void)
-{
-    int i;
-    static const counter_type_t types[4] = {
-        COUNTER_TYPE_COMMANDER_TAX,
-        COUNTER_TYPE_PARTNER_TAX,
-        COUNTER_TYPE_POISON,
-        COUNTER_TYPE_EXPERIENCE,
-    };
-    lv_event_cb_t const cbs[4] = {
-        event_multiplayer_counter_commander_tax,
-        event_multiplayer_counter_partner_tax,
-        event_multiplayer_counter_poison,
-        event_multiplayer_counter_experience,
-    };
-    quad_item_t items[4];
-
-    for (i = 0; i < 4; i++) {
-        const counter_definition_t *def = get_counter_definition(types[i]);
-        items[i].label      = def->menu_label;
-        items[i].cb         = cbs[i];
-        items[i].enabled    = true;
-        items[i].event      = LV_EVENT_CLICKED;
-        items[i].icon       = def->icon_text;
-        items[i].icon_font  = (types[i] == COUNTER_TYPE_POISON)
-                              ? &mana_poison_icon_bold_16
-                              : &mana_counter_icons_16;
-    }
-
-    build_quad_screen(&screen_player_counters_menu, items);
-}
-
-void build_multiplayer_all_damage_screen(void)
-{
-    screen_player_all_damage = lv_obj_create(NULL);
-    lv_obj_set_size(screen_player_all_damage, 360, 360);
-    lv_obj_set_style_bg_color(screen_player_all_damage, lv_color_black(), 0);
-    lv_obj_set_style_border_width(screen_player_all_damage, 0, 0);
-    lv_obj_set_scrollbar_mode(screen_player_all_damage, LV_SCROLLBAR_MODE_OFF);
-
-    label_multiplayer_all_damage_title = lv_label_create(screen_player_all_damage);
-    lv_obj_set_style_text_color(label_multiplayer_all_damage_title, lv_color_white(), 0);
-    lv_obj_set_style_text_font(label_multiplayer_all_damage_title, &lv_font_montserrat_22, 0);
-    lv_obj_align(label_multiplayer_all_damage_title, LV_ALIGN_TOP_MID, 0, 26);
-
-    label_all_damage_value = lv_label_create(screen_player_all_damage);
-    lv_obj_set_style_text_color(label_all_damage_value, lv_color_white(), 0);
-    lv_obj_set_style_text_font(label_all_damage_value, &lv_font_montserrat_32, 0);
-    lv_obj_align(label_all_damage_value, LV_ALIGN_CENTER, 0, -8);
-
-    label_multiplayer_all_damage_hint = lv_label_create(screen_player_all_damage);
-    lv_label_set_text(label_multiplayer_all_damage_hint, "Turn knob, then apply");
-    lv_obj_set_style_text_color(label_multiplayer_all_damage_hint, lv_color_hex(0x7A7A7A), 0);
-    lv_obj_set_style_text_font(label_multiplayer_all_damage_hint, &lv_font_montserrat_14, 0);
-    lv_obj_align(label_multiplayer_all_damage_hint, LV_ALIGN_CENTER, 0, 38);
-
-    lv_obj_t *btn = make_button(screen_player_all_damage, "Apply", 120, 46, event_multiplayer_all_damage_apply);
-    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
-}
-
-void build_multiplayer_counter_edit_screen(void)
-{
-    lv_obj_t *btn;
-
-    screen_player_counter_edit = lv_obj_create(NULL);
-    lv_obj_set_size(screen_player_counter_edit, 360, 360);
-    lv_obj_set_style_bg_color(screen_player_counter_edit, lv_color_black(), 0);
-    lv_obj_set_style_border_width(screen_player_counter_edit, 0, 0);
-    lv_obj_set_scrollbar_mode(screen_player_counter_edit, LV_SCROLLBAR_MODE_OFF);
-
-    label_multiplayer_counter_edit_icon = lv_label_create(screen_player_counter_edit);
-    lv_label_set_text(label_multiplayer_counter_edit_icon, "");
-    lv_obj_set_style_text_color(label_multiplayer_counter_edit_icon, lv_color_white(), 0);
-    lv_obj_set_style_text_font(label_multiplayer_counter_edit_icon, &mana_counter_icons_16, 0);
-    lv_obj_align(label_multiplayer_counter_edit_icon, LV_ALIGN_TOP_MID, 0, 12);
-
-    label_multiplayer_counter_edit_title = lv_label_create(screen_player_counter_edit);
-    lv_label_set_text(label_multiplayer_counter_edit_title, "P1\nCommander Tax");
-    lv_obj_set_style_text_color(label_multiplayer_counter_edit_title, lv_color_white(), 0);
-    lv_obj_set_style_text_font(label_multiplayer_counter_edit_title, &lv_font_montserrat_22, 0);
-    lv_obj_set_style_text_align(label_multiplayer_counter_edit_title, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_align(label_multiplayer_counter_edit_title, LV_ALIGN_TOP_MID, 0, 42);
-
-    label_counter_edit_value = lv_label_create(screen_player_counter_edit);
-    lv_label_set_text(label_counter_edit_value, "0");
-    lv_obj_set_style_text_color(label_counter_edit_value, lv_color_white(), 0);
-    lv_obj_set_style_text_font(label_counter_edit_value, &lv_font_montserrat_32, 0);
-    lv_obj_align(label_counter_edit_value, LV_ALIGN_CENTER, 0, -4);
-
-    label_multiplayer_counter_edit_hint = lv_label_create(screen_player_counter_edit);
-    lv_label_set_text(label_multiplayer_counter_edit_hint, "Turn knob, then apply");
-    lv_obj_set_style_text_color(label_multiplayer_counter_edit_hint, lv_color_hex(0x7A7A7A), 0);
-    lv_obj_set_style_text_font(label_multiplayer_counter_edit_hint, &lv_font_montserrat_14, 0);
-    lv_obj_align(label_multiplayer_counter_edit_hint, LV_ALIGN_CENTER, 0, 34);
-
-    btn = make_button(screen_player_counter_edit, "Apply", 120, 46, event_multiplayer_counter_apply);
-    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
 }
 
 // ---------- 2-player screen (top/bottom split) ----------

--- a/knobby/src/ui_mp.h
+++ b/knobby/src/ui_mp.h
@@ -7,29 +7,15 @@
 extern lv_obj_t *screen_4p;
 extern lv_obj_t *screen_2p;
 extern lv_obj_t *screen_3p;
-extern lv_obj_t *screen_player_menu;
-extern lv_obj_t *screen_player_all_damage;
-extern lv_obj_t *screen_player_counters_menu;
-extern lv_obj_t *screen_player_counter_edit;
-extern lv_obj_t *screen_eliminated_player_menu;
 
 // ---------- functions ----------
 void build_multiplayer_screen(void);
 void build_multiplayer_2p_screen(void);
 void build_multiplayer_3p_screen(void);
-void build_multiplayer_menu_screen(void);
-void build_eliminated_player_menu_screen(void);
-void build_multiplayer_all_damage_screen(void);
-void build_multiplayer_counter_menu_screen(void);
-void build_multiplayer_counter_edit_screen(void);
 
 void refresh_multiplayer_ui(void);
-void refresh_multiplayer_all_damage_ui(void);
-void refresh_multiplayer_counter_edit_ui(void);
 
 void open_multiplayer_screen(void);
-void open_multiplayer_menu_screen(int player_index);
-void open_multiplayer_counter_menu_screen(void);
 void select_kick_timer(void);
 
 #endif // _UI_MP_H

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -1,0 +1,323 @@
+#include "ui_player_menu.h"
+#include "ui_1p.h"
+#include "game.h"
+#include "storage.h"
+#include "damage_log.h"
+#include "rename.h"
+#include "settings.h"
+
+// ---------- screens ----------
+lv_obj_t *screen_player_menu = NULL;
+lv_obj_t *screen_player_all_damage = NULL;
+lv_obj_t *screen_counter_menu = NULL;
+lv_obj_t *screen_counter_edit = NULL;
+lv_obj_t *screen_eliminated_player_menu = NULL;
+
+// ---------- widgets ----------
+static lv_obj_t *label_all_damage_title = NULL;
+static lv_obj_t *label_all_damage_value = NULL;
+static lv_obj_t *label_all_damage_hint = NULL;
+static lv_obj_t *label_counter_edit_title = NULL;
+static lv_obj_t *label_counter_edit_value = NULL;
+static lv_obj_t *label_counter_edit_hint = NULL;
+static lv_obj_t *label_counter_edit_icon = NULL;
+
+// ---------- forward declarations ----------
+static void open_all_damage_screen(void);
+static void open_counter_edit_screen(counter_type_t type);
+
+// ---------- refresh ----------
+void refresh_all_damage_ui(void)
+{
+    char buf[32];
+
+    if (label_all_damage_title != NULL) {
+        lv_label_set_text(label_all_damage_title, "All players");
+    }
+
+    if (label_all_damage_value != NULL) {
+        snprintf(buf, sizeof(buf), "Damage: %d", all_damage_value);
+        lv_label_set_text(label_all_damage_value, buf);
+    }
+}
+
+void refresh_counter_edit_ui(void)
+{
+    char title_buf[48];
+    char value_buf[16];
+    const counter_definition_t *definition = get_counter_definition(counter_edit_type);
+
+    if (definition == NULL) return;
+
+    if (label_counter_edit_icon != NULL) {
+        const lv_font_t *icon_font = (counter_edit_type == COUNTER_TYPE_POISON)
+                                      ? &mana_poison_icon_bold_16
+                                      : &mana_counter_icons_16;
+        lv_label_set_text(label_counter_edit_icon,
+            definition->icon_text ? definition->icon_text : "");
+        lv_obj_set_style_text_font(label_counter_edit_icon, icon_font, 0);
+    }
+
+    if (label_counter_edit_title != NULL) {
+        snprintf(title_buf, sizeof(title_buf), "%s\n%s",
+            player_names[menu_player], definition->display_name);
+        lv_label_set_text(label_counter_edit_title, title_buf);
+    }
+
+    if (label_counter_edit_value != NULL) {
+        snprintf(value_buf, sizeof(value_buf), "%d", counter_edit_value);
+        lv_label_set_text(label_counter_edit_value, value_buf);
+    }
+}
+
+// ---------- navigation ----------
+void open_player_menu(int player_index)
+{
+    menu_player = player_index;
+    load_screen_if_needed(screen_player_menu);
+}
+
+void open_counter_menu(void)
+{
+    load_screen_if_needed(screen_counter_menu);
+}
+
+static void open_all_damage_screen(void)
+{
+    all_damage_value = 0;
+    refresh_all_damage_ui();
+    load_screen_if_needed(screen_player_all_damage);
+}
+
+static void open_counter_edit_screen(counter_type_t type)
+{
+    begin_counter_edit(menu_player, type);
+    refresh_counter_edit_ui();
+    load_screen_if_needed(screen_counter_edit);
+}
+
+// ---------- events ----------
+static void event_menu_rename(lv_event_t *e)
+{
+    (void)e;
+    open_rename_screen();
+}
+
+static void event_menu_rename_all(lv_event_t *e)
+{
+    (void)e;
+    open_rename_all_screen();
+}
+
+static void event_menu_cmd_damage(lv_event_t *e)
+{
+    (void)e;
+    prepare_cmd_damage_for_player(menu_player);
+    open_select_screen();
+}
+
+static void event_menu_all_damage(lv_event_t *e)
+{
+    (void)e;
+    open_all_damage_screen();
+}
+
+static void event_menu_counters(lv_event_t *e)
+{
+    (void)e;
+    open_counter_menu();
+}
+
+static void event_eliminated_undo(lv_event_t *e)
+{
+    (void)e;
+    undo_elimination_action(menu_player);
+    back_to_main();
+}
+
+static void event_counter_commander_tax(lv_event_t *e)
+{
+    (void)e;
+    open_counter_edit_screen(COUNTER_TYPE_COMMANDER_TAX);
+}
+
+static void event_counter_partner_tax(lv_event_t *e)
+{
+    (void)e;
+    open_counter_edit_screen(COUNTER_TYPE_PARTNER_TAX);
+}
+
+static void event_counter_poison(lv_event_t *e)
+{
+    (void)e;
+    open_counter_edit_screen(COUNTER_TYPE_POISON);
+}
+
+static void event_counter_experience(lv_event_t *e)
+{
+    (void)e;
+    open_counter_edit_screen(COUNTER_TYPE_EXPERIENCE);
+}
+
+static void event_all_damage_apply(lv_event_t *e)
+{
+    int i;
+
+    (void)e;
+    for (i = 0; i < nvs_get_players_to_track(); i++) {
+        damage_log_add(i, -all_damage_value, LOG_EVT_LIFE, -1);
+        player_life[i] = clamp_life(player_life[i] - all_damage_value);
+    }
+
+    refresh_player_ui();
+    back_to_main();
+}
+
+static void event_counter_apply(lv_event_t *e)
+{
+    (void)e;
+    apply_counter_edit();
+    refresh_counter_edit_ui();
+    refresh_player_ui();
+    back_to_main();
+}
+
+// ---------- screen builders ----------
+void build_player_menu_screen(void)
+{
+    quad_item_t items[4] = {
+        {"Rename",      event_menu_rename,     true,  LV_EVENT_CLICKED},
+        {"Commander\nDamage", event_menu_cmd_damage, true,  LV_EVENT_CLICKED},
+        {"All\nDamage", event_menu_all_damage, true,  LV_EVENT_CLICKED},
+        {"Counters",    event_menu_counters,   true,  LV_EVENT_CLICKED},
+    };
+    build_quad_screen(&screen_player_menu, items);
+
+    /* Long-press Rename to rename all players sequentially */
+    lv_obj_t *rename_btn = lv_obj_get_child(screen_player_menu, 0);
+    lv_obj_add_event_cb(rename_btn, event_menu_rename_all, LV_EVENT_LONG_PRESSED, NULL);
+}
+
+void build_eliminated_player_menu_screen(void)
+{
+    screen_eliminated_player_menu = lv_obj_create(NULL);
+    lv_obj_set_size(screen_eliminated_player_menu, 360, 360);
+    lv_obj_set_style_bg_color(screen_eliminated_player_menu, lv_color_black(), 0);
+    lv_obj_set_style_border_width(screen_eliminated_player_menu, 0, 0);
+    lv_obj_set_scrollbar_mode(screen_eliminated_player_menu, LV_SCROLLBAR_MODE_OFF);
+
+    lv_obj_t *title = lv_label_create(screen_eliminated_player_menu);
+    lv_label_set_text(title, "Undo elimination");
+    lv_obj_set_style_text_color(title, lv_color_white(), 0);
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_22, 0);
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 40);
+
+    lv_obj_t *hint = lv_label_create(screen_eliminated_player_menu);
+    lv_label_set_text(hint, "Restore the action that eliminated this player");
+    lv_obj_set_style_text_color(hint, lv_color_hex(0x7A7A7A), 0);
+    lv_obj_set_style_text_font(hint, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(hint, LV_ALIGN_CENTER, 0, 0);
+
+    lv_obj_t *btn = make_button(screen_eliminated_player_menu, "Undo", 120, 46, event_eliminated_undo);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
+}
+
+void build_counter_menu_screen(void)
+{
+    int i;
+    static const counter_type_t types[4] = {
+        COUNTER_TYPE_COMMANDER_TAX,
+        COUNTER_TYPE_PARTNER_TAX,
+        COUNTER_TYPE_POISON,
+        COUNTER_TYPE_EXPERIENCE,
+    };
+    lv_event_cb_t const cbs[4] = {
+        event_counter_commander_tax,
+        event_counter_partner_tax,
+        event_counter_poison,
+        event_counter_experience,
+    };
+    quad_item_t items[4];
+
+    for (i = 0; i < 4; i++) {
+        const counter_definition_t *def = get_counter_definition(types[i]);
+        items[i].label      = def->menu_label;
+        items[i].cb         = cbs[i];
+        items[i].enabled    = true;
+        items[i].event      = LV_EVENT_CLICKED;
+        items[i].icon       = def->icon_text;
+        items[i].icon_font  = (types[i] == COUNTER_TYPE_POISON)
+                              ? &mana_poison_icon_bold_16
+                              : &mana_counter_icons_16;
+    }
+
+    build_quad_screen(&screen_counter_menu, items);
+}
+
+void build_all_damage_screen(void)
+{
+    screen_player_all_damage = lv_obj_create(NULL);
+    lv_obj_set_size(screen_player_all_damage, 360, 360);
+    lv_obj_set_style_bg_color(screen_player_all_damage, lv_color_black(), 0);
+    lv_obj_set_style_border_width(screen_player_all_damage, 0, 0);
+    lv_obj_set_scrollbar_mode(screen_player_all_damage, LV_SCROLLBAR_MODE_OFF);
+
+    label_all_damage_title = lv_label_create(screen_player_all_damage);
+    lv_obj_set_style_text_color(label_all_damage_title, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_all_damage_title, &lv_font_montserrat_22, 0);
+    lv_obj_align(label_all_damage_title, LV_ALIGN_TOP_MID, 0, 26);
+
+    label_all_damage_value = lv_label_create(screen_player_all_damage);
+    lv_obj_set_style_text_color(label_all_damage_value, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_all_damage_value, &lv_font_montserrat_32, 0);
+    lv_obj_align(label_all_damage_value, LV_ALIGN_CENTER, 0, -8);
+
+    label_all_damage_hint = lv_label_create(screen_player_all_damage);
+    lv_label_set_text(label_all_damage_hint, "Turn knob, then apply");
+    lv_obj_set_style_text_color(label_all_damage_hint, lv_color_hex(0x7A7A7A), 0);
+    lv_obj_set_style_text_font(label_all_damage_hint, &lv_font_montserrat_14, 0);
+    lv_obj_align(label_all_damage_hint, LV_ALIGN_CENTER, 0, 38);
+
+    lv_obj_t *btn = make_button(screen_player_all_damage, "Apply", 120, 46, event_all_damage_apply);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
+}
+
+void build_counter_edit_screen(void)
+{
+    lv_obj_t *btn;
+
+    screen_counter_edit = lv_obj_create(NULL);
+    lv_obj_set_size(screen_counter_edit, 360, 360);
+    lv_obj_set_style_bg_color(screen_counter_edit, lv_color_black(), 0);
+    lv_obj_set_style_border_width(screen_counter_edit, 0, 0);
+    lv_obj_set_scrollbar_mode(screen_counter_edit, LV_SCROLLBAR_MODE_OFF);
+
+    label_counter_edit_icon = lv_label_create(screen_counter_edit);
+    lv_label_set_text(label_counter_edit_icon, "");
+    lv_obj_set_style_text_color(label_counter_edit_icon, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_counter_edit_icon, &mana_counter_icons_16, 0);
+    lv_obj_align(label_counter_edit_icon, LV_ALIGN_TOP_MID, 0, 12);
+
+    label_counter_edit_title = lv_label_create(screen_counter_edit);
+    lv_label_set_text(label_counter_edit_title, "P1\nCommander Tax");
+    lv_obj_set_style_text_color(label_counter_edit_title, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_counter_edit_title, &lv_font_montserrat_22, 0);
+    lv_obj_set_style_text_align(label_counter_edit_title, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(label_counter_edit_title, LV_ALIGN_TOP_MID, 0, 42);
+
+    label_counter_edit_value = lv_label_create(screen_counter_edit);
+    lv_label_set_text(label_counter_edit_value, "0");
+    lv_obj_set_style_text_color(label_counter_edit_value, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_counter_edit_value, &lv_font_montserrat_32, 0);
+    lv_obj_align(label_counter_edit_value, LV_ALIGN_CENTER, 0, -4);
+
+    label_counter_edit_hint = lv_label_create(screen_counter_edit);
+    lv_label_set_text(label_counter_edit_hint, "Turn knob, then apply");
+    lv_obj_set_style_text_color(label_counter_edit_hint, lv_color_hex(0x7A7A7A), 0);
+    lv_obj_set_style_text_font(label_counter_edit_hint, &lv_font_montserrat_14, 0);
+    lv_obj_align(label_counter_edit_hint, LV_ALIGN_CENTER, 0, 34);
+
+    btn = make_button(screen_counter_edit, "Apply", 120, 46, event_counter_apply);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
+}

--- a/knobby/src/ui_player_menu.h
+++ b/knobby/src/ui_player_menu.h
@@ -1,0 +1,26 @@
+#ifndef _UI_PLAYER_MENU_H
+#define _UI_PLAYER_MENU_H
+
+#include "types.h"
+
+// ---------- screens ----------
+extern lv_obj_t *screen_player_menu;
+extern lv_obj_t *screen_player_all_damage;
+extern lv_obj_t *screen_counter_menu;
+extern lv_obj_t *screen_counter_edit;
+extern lv_obj_t *screen_eliminated_player_menu;
+
+// ---------- functions ----------
+void build_player_menu_screen(void);
+void build_eliminated_player_menu_screen(void);
+void build_all_damage_screen(void);
+void build_counter_menu_screen(void);
+void build_counter_edit_screen(void);
+
+void refresh_all_damage_ui(void);
+void refresh_counter_edit_ui(void);
+
+void open_player_menu(int player_index);
+void open_counter_menu(void);
+
+#endif // _UI_PLAYER_MENU_H

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -21,7 +21,7 @@ KNOBBY_TOP_SRCS := $(KNOBBY)/knob.c
 
 # Source files in src/
 KNOBBY_SRC_SRCS := $(addprefix $(KNOBBY)/src/, \
-	ui_1p.c ui_mp.c settings.c \
+	ui_1p.c ui_mp.c ui_player_menu.c settings.c \
 	intro.c timer.c game.c damage_log.c \
 	game_mode.c rename.c dice.c hw.c storage.c)
 

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -10,6 +10,7 @@
 #include "game.h"
 #include "ui_1p.h"
 #include "ui_mp.h"
+#include "ui_player_menu.h"
 #include "settings.h"
 #include "intro.h"
 #include "dice.h"
@@ -128,18 +129,18 @@ static void nav_damage(void) {
     refresh_damage_ui();
     lv_scr_load(screen_damage);
 }
-static void nav_player_menu(void)  { open_multiplayer_menu_screen(0); }
+static void nav_player_menu(void)  { open_player_menu(0); }
 static void nav_rename(void)       { open_rename_screen(); }
 static void nav_all_damage(void) {
     all_damage_value = 5;
-    refresh_multiplayer_all_damage_ui();
+    refresh_all_damage_ui();
     lv_scr_load(screen_player_all_damage);
 }
-static void nav_counters_menu(void) { lv_scr_load(screen_player_counters_menu); }
+static void nav_counters_menu(void) { lv_scr_load(screen_counter_menu); }
 static void nav_counter_edit(void) {
     begin_counter_edit(0, COUNTER_TYPE_POISON);
-    refresh_multiplayer_counter_edit_ui();
-    lv_scr_load(screen_player_counter_edit);
+    refresh_counter_edit_ui();
+    lv_scr_load(screen_counter_edit);
 }
 
 static const screen_entry_t all_screens[] = {
@@ -435,7 +436,7 @@ int main(int argc, char *argv[])
         if (counter_type_set || counter_value_set) { \
             begin_counter_edit(counter_player_val, (counter_type_t)counter_type_val); \
             if (counter_value_set) counter_edit_value = counter_value_val; \
-            refresh_multiplayer_counter_edit_ui(); \
+            refresh_counter_edit_ui(); \
         } \
         if (enemy_damage_set) { \
             for (i = 0; i < MAX_ENEMY_COUNT; i++) \
@@ -445,7 +446,7 @@ int main(int argc, char *argv[])
         } \
         if (all_damage_set) { \
             all_damage_value = all_damage_val; \
-            refresh_multiplayer_all_damage_ui(); \
+            refresh_all_damage_ui(); \
         } \
         if (menu_player_set) { \
             menu_player = menu_player_val; \


### PR DESCRIPTION
## Summary
- Extract shared menu screens from `ui_mp.c` into new `ui_player_menu.c`
- Player menu, counter menu/edit, all-damage screen, and eliminated player menu now live in their own file
- Rename functions to drop `multiplayer_` prefix since menus serve all player counts (1p included)
- `ui_mp.c`: 1003 → 693 lines (multiplayer layout code only)
- `ui_player_menu.c`: 323 lines (shared menu screens)

## Renames
- `open_multiplayer_menu_screen()` → `open_player_menu()`
- `open_multiplayer_counter_menu_screen()` → `open_counter_menu()`
- `refresh_multiplayer_all_damage_ui()` → `refresh_all_damage_ui()`
- `refresh_multiplayer_counter_edit_ui()` → `refresh_counter_edit_ui()`
- `build_multiplayer_menu_screen()` → `build_player_menu_screen()`
- `build_multiplayer_counter_menu_screen()` → `build_counter_menu_screen()`
- `build_multiplayer_all_damage_screen()` → `build_all_damage_screen()`
- `build_multiplayer_counter_edit_screen()` → `build_counter_edit_screen()`
- `screen_player_counters_menu` → `screen_counter_menu`
- `screen_player_counter_edit` → `screen_counter_edit`

## Test plan
- [x] `make generate-matrix` produces 314 screenshots, deterministic screenshots match baseline
- [x] `make firmware` compiles clean (836 KB flash, 141 KB RAM)
- [x] Flash to device and verify player menu, counter edit, all-damage, undo elimination

🤖 Generated with [Claude Code](https://claude.com/claude-code)