### PR TITLE
Fix green selection highlighting

### DIFF
--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -132,7 +132,7 @@ void check_player_elimination(int player)
 // ---------- player colors ----------
 static const uint32_t player_color_table[MAX_PLAYERS][LIFE_VIB_COUNT] = {
     /*  dim        mid        vivid  */
-    {0x06D6A0, 0x06D6A0, 0x06D6A0},  /* P1 green  (bottom-left) */
+    {0x024D3A, 0x06D6A0, 0x66FFD9},  /* P1 green  (bottom-left) */
     {0x2A0A4D, 0x7B1FE0, 0x9C4DFF},  /* P2 purple (top-left)    */
     {0x0A3A4D, 0x29B6F6, 0x4FC3F7},  /* P3 blue   (top-right)   */
     {0x4D4400, 0xFFD600, 0xFFEA61},  /* P4 yellow (bottom-right) */

--- a/knobby/src/types.h
+++ b/knobby/src/types.h
@@ -113,7 +113,7 @@ static const uint32_t life_color_table[LIFE_TIER_COUNT][LIFE_VIB_COUNT] = {
     /* dim        mid        vivid */
     {0x4D1C1C, 0xF44336, 0xFF0000},  /* red    */
     {0x4D4D00, 0xFFEB3B, 0xFFFF00},  /* yellow */
-    {0x06D6A0, 0x06D6A0, 0x06D6A0},  /* green  */
+    {0x024D3A, 0x06D6A0, 0x66FFD9},  /* green  */
     {0x2E004D, 0x7B1FA2, 0xAA00FF},  /* purple */
 };
 


### PR DESCRIPTION
## Summary
- Adds dim (`0x024D3A`) and vivid (`0x66FFD9`) variants to the logo-green color (`0x06D6A0`) in both the life tier and player color tables
- Commit `0d1b391` set all three vibrancy levels to the same value, making player selection highlighting invisible

Closes #58

## Test plan
- [x] Verify 4-player screen shows visible highlight difference when a player is selected
- [x] Verify life-color mode also shows selection highlighting for green tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)