### PR TITLE
Preserve player names across reset

### DIFF
--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -473,7 +473,6 @@ void knob_life_reset(void)
 
     for (i = 0; i < MAX_PLAYERS; i++) {
         player_life[i] = starting_life;
-        snprintf(player_names[i], sizeof(player_names[i]), "P%d", i + 1);
     }
     selected_player = -1;
     menu_player = 0;


### PR DESCRIPTION
## Summary
- Remove name reset from `knob_life_reset()` so player names survive reset and game-mode-apply
- Names still reset to defaults (P1-P4) on reboot
- Names are session-level identity, not game-level state

## Test plan
- [x] Firmware compiles (63%)
- [x] Rename a player, hit reset — name should persist
- [x] Change game mode and apply — name should persist
- [x] Reboot device — names should reset to P1-P4

🤖 Generated with [Claude Code](https://claude.com/claude-code)