### PR TITLE
Per-player color selection with 18-color palette (closes #25)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 MAKE ?= make
 
 # ---- Arduino CLI ----
-ARDUINO_CLI ?= "C:\Program Files\Arduino CLI\arduino-cli.exe"
+# ARDUINO_CLI is set by config.mk (defaults to 'arduino-cli' in PATH)
 FQBN        := esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio
 EXTRA_URLS  := https://espressif.github.io/arduino-esp32/package_esp32_index.json
 

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -105,6 +105,10 @@ static void handle_back_navigation(lv_obj_t *screen)
         open_counter_menu();
     } else if (screen == screen_player_all_damage) {
         open_player_menu(menu_player);
+    } else if (screen == screen_player_color_menu) {
+        open_player_menu(menu_player);
+    } else if (screen == screen_player_color_picker) {
+        load_screen_if_needed(screen_player_color_menu);
     }
 }
 
@@ -154,6 +158,8 @@ void knob_gui(void)
     build_all_damage_screen();
     build_counter_menu_screen();
     build_counter_edit_screen();
+    build_player_color_menu_screen();
+    build_player_color_picker_screen();
     build_select_screen();
     build_damage_screen();
     build_settings_screen();
@@ -237,6 +243,11 @@ static void handle_knob_event(knob_event_t k)
     {
         if (k == KNOB_LEFT)      mru_select_prev();
         else if (k == KNOB_RIGHT) mru_select_next();
+    }
+    else if (lv_scr_act() == screen_player_color_picker)
+    {
+        if (k == KNOB_LEFT)      change_player_color(-1);
+        else if (k == KNOB_RIGHT) change_player_color(+1);
     }
 }
 

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -473,7 +473,6 @@ void knob_life_reset(void)
 
     for (i = 0; i < MAX_PLAYERS; i++) {
         player_life[i] = starting_life;
-        snprintf(player_names[i], sizeof(player_names[i]), "P%d", i + 1);
     }
     selected_player = -1;
     menu_player = 0;

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -158,6 +158,42 @@ static const uint32_t player_color_table[MAX_PLAYERS][LIFE_VIB_COUNT] = {
     {0x4D4400, 0xFFD600, 0xFFEA61},  /* P4 yellow (bottom-right) */
 };
 
+// ---------- custom color palette (18 colors) ----------
+static const uint32_t custom_color_table[CUSTOM_COLOR_COUNT][LIFE_VIB_COUNT] = {
+    /*  dim        mid        vivid  */
+    {0x024D3A, 0x06D6A0, 0x66FFD9},  /*  0 Green (logo) */
+    {0x2A0A4D, 0x7B1FE0, 0x9C4DFF},  /*  1 Purple */
+    {0x0A3A4D, 0x29B6F6, 0x4FC3F7},  /*  2 Blue   */
+    {0x4D4400, 0xFFD600, 0xFFEA61},  /*  3 Yellow */
+    {0x4D1C1C, 0xF44336, 0xFF5252},  /*  4 Red    */
+    {0x4D3300, 0xFF9800, 0xFFB74D},  /*  5 Orange */
+    {0x004D4D, 0x00BCD4, 0x4DD0E1},  /*  6 Cyan   */
+    {0x3D0A4D, 0xE040FB, 0xEA80FC},  /*  7 Pink   */
+    {0x2D4D00, 0x8BC34A, 0xAED581},  /*  8 Lime   */
+    {0x0A0A4D, 0x3F51B5, 0x7986CB},  /*  9 Indigo */
+    {0x4D0A2A, 0xE91E63, 0xF06292},  /* 10 Rose   */
+    {0x333333, 0xAAAAAA, 0xFFFFFF},  /* 11 White  */
+    {0x00332E, 0x009688, 0x4DB6AC},  /* 12 Teal   */
+    {0x4D3800, 0xFFC107, 0xFFD54F},  /* 13 Amber  */
+    {0x2E1F16, 0x795548, 0xA1887F},  /* 14 Brown  */
+    {0x1E2D33, 0x607D8B, 0x90A4AE},  /* 15 Gray   */
+    {0x1A3D1A, 0xA5D6A7, 0x4CAF50},  /* 16 Sage   */
+    {0x0A0A0A, 0x303030, 0x505050},  /* 17 Black  */
+};
+
+static const char *custom_color_names[CUSTOM_COLOR_COUNT] = {
+    "Green", "Purple", "Blue", "Yellow",
+    "Red", "Orange", "Cyan", "Pink",
+    "Lime", "Indigo", "Rose", "White",
+    "Teal", "Amber", "Brown", "Gray",
+    "Sage", "Black",
+};
+
+// ---------- per-player color state (runtime only, lost on reboot) ----------
+int player_color_index[MAX_PLAYERS] = {0, 1, 2, 3};
+bool player_life_color[MAX_PLAYERS] = {false, false, false, false};
+bool player_has_override[MAX_PLAYERS] = {false, false, false, false};
+
 lv_color_t get_player_color_vib(int index, int vibrancy)
 {
     if (index < 0 || index >= MAX_PLAYERS) return lv_color_hex(0x303030);
@@ -191,6 +227,44 @@ lv_color_t get_player_preview_color(int index, int delta)
         return (delta < 0) ? lv_palette_main(LV_PALETTE_RED) : lv_color_white();
     }
     return (delta < 0) ? lv_palette_main(LV_PALETTE_RED) : lv_palette_main(LV_PALETTE_GREEN);
+}
+
+lv_color_t get_custom_color_vib(int index, int vibrancy)
+{
+    if (index < 0 || index >= CUSTOM_COLOR_COUNT) index = 0;
+    if (vibrancy < 0 || vibrancy >= LIFE_VIB_COUNT) vibrancy = LIFE_VIB_MID;
+    return lv_color_hex(custom_color_table[index][vibrancy]);
+}
+
+const char *get_custom_color_name(int index)
+{
+    if (index < 0 || index >= CUSTOM_COLOR_COUNT) index = 0;
+    return custom_color_names[index];
+}
+
+lv_color_t get_effective_player_color(int player_i, int color_i, int vibrancy)
+{
+    /* Per-player override takes precedence over global mode */
+    if (player_has_override[player_i]) {
+        if (player_life_color[player_i]) {
+            int life = player_life[player_i];
+            int max_life = nvs_get_life_total();
+            int tier = get_life_tier(life, max_life);
+            return get_life_color_vib(tier, vibrancy);
+        }
+        return get_custom_color_vib(player_color_index[player_i], vibrancy);
+    }
+
+    /* No override: use global mode */
+    if (nvs_get_color_mode() == COLOR_MODE_LIFE) {
+        int life = player_life[player_i];
+        int max_life = nvs_get_life_total();
+        int tier = get_life_tier(life, max_life);
+        return get_life_color_vib(tier, vibrancy);
+    }
+
+    /* COLOR_MODE_PLAYER: use position color */
+    return get_player_color_vib(color_i, vibrancy);
 }
 
 int get_main_player_index(void)

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -105,17 +105,19 @@ void check_player_elimination(int player)
     bool was_eliminated = player_eliminated[player];
     bool now_eliminated = false;
 
-    if (player_life[player] <= 0) {
-        now_eliminated = true;
-    } else {
-        for (int i = 0; i < MAX_PLAYERS; i++) {
-            if (i != player && cmd_damage_totals[i][player] >= 20) {
-                now_eliminated = true;
-                break;
-            }
-        }
-        if (!now_eliminated && player_counters[player][COUNTER_TYPE_POISON] >= 10) {
+    if (nvs_get_auto_eliminate()) {
+        if (player_life[player] <= 0) {
             now_eliminated = true;
+        } else {
+            for (int i = 0; i < MAX_PLAYERS; i++) {
+                if (i != player && cmd_damage_totals[i][player] >= 20) {
+                    now_eliminated = true;
+                    break;
+                }
+            }
+            if (!now_eliminated && player_counters[player][COUNTER_TYPE_POISON] >= 10) {
+                now_eliminated = true;
+            }
         }
     }
 
@@ -127,6 +129,24 @@ void check_player_elimination(int player)
     if (was_eliminated != now_eliminated) {
         refresh_player_ui();
     }
+}
+
+void manual_eliminate_player(int player)
+{
+    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player_eliminated[player]) return;
+    player_eliminated[player] = true;
+    clear_player_elimination_action(player);
+    refresh_player_ui();
+}
+
+void manual_uneliminate_player(int player)
+{
+    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (!player_eliminated[player]) return;
+    player_eliminated[player] = false;
+    clear_player_elimination_action(player);
+    refresh_player_ui();
 }
 
 // ---------- player colors ----------

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -69,11 +69,18 @@ void manual_uneliminate_player(int player);
 void check_player_elimination(int player);
 
 // ---------- player colors ----------
+extern int player_color_index[MAX_PLAYERS];
+extern bool player_life_color[MAX_PLAYERS];
+extern bool player_has_override[MAX_PLAYERS];
+
 lv_color_t get_player_color_vib(int index, int vibrancy);
 lv_color_t get_player_base_color(int index);
 lv_color_t get_player_active_color(int index);
 lv_color_t get_player_text_color(int index);
 lv_color_t get_player_preview_color(int index, int delta);
+lv_color_t get_custom_color_vib(int index, int vibrancy);
+const char *get_custom_color_name(int index);
+lv_color_t get_effective_player_color(int player_i, int color_i, int vibrancy);
 int get_main_player_index(void);
 int get_cmd_target_player_index(int row);
 

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -63,6 +63,10 @@ bool counter_type_is_enabled(counter_type_t type);
 
 bool elimination_action_available(int player);
 void undo_elimination_action(int player);
+void manual_eliminate_player(int player);
+void manual_uneliminate_player(int player);
+
+void check_player_elimination(int player);
 
 // ---------- player colors ----------
 lv_color_t get_player_color_vib(int index, int vibrancy);

--- a/knobby/src/rename.c
+++ b/knobby/src/rename.c
@@ -382,9 +382,14 @@ void build_rename_screen(void)
     lv_obj_set_style_pad_row(mru_list_container, 2, 0);
     lv_obj_set_scrollbar_mode(mru_list_container, LV_SCROLLBAR_MODE_OFF);
 
-    btn_mru_select = make_button(screen_player_name, "Select", 120, 38, event_mru_select);
-    lv_obj_align(btn_mru_select, LV_ALIGN_TOP_MID, 0, 278);
+    btn_mru_select = lv_btn_create(screen_player_name);
+    lv_obj_set_size(btn_mru_select, 120, 38);
+    lv_obj_add_event_cb(btn_mru_select, event_mru_select, LV_EVENT_SHORT_CLICKED, NULL);
     lv_obj_add_event_cb(btn_mru_select, event_mru_delete, LV_EVENT_LONG_PRESSED, NULL);
+    lv_obj_t *btn_mru_label = lv_label_create(btn_mru_select);
+    lv_label_set_text(btn_mru_label, "Select");
+    lv_obj_center(btn_mru_label);
+    lv_obj_align(btn_mru_select, LV_ALIGN_TOP_MID, 0, 278);
 
     /* --- Keyboard mode widgets (hidden initially) --- */
     textarea_name = lv_textarea_create(screen_player_name);

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -29,6 +29,8 @@ static lv_obj_t *btn_deselect = NULL;
 static lv_obj_t *label_deselect_quad = NULL;
 static lv_obj_t *btn_orientation = NULL;
 static lv_obj_t *label_orientation_quad = NULL;
+static lv_obj_t *btn_auto_eliminate = NULL;
+static lv_obj_t *label_auto_eliminate_quad = NULL;
 static lv_obj_t *arc_brightness = NULL;
 static lv_obj_t *label_settings_value = NULL;
 static lv_obj_t *label_settings_hint = NULL;
@@ -291,6 +293,23 @@ static void event_screen_orientation(lv_event_t *e)
     set_btn_color(btn_orientation, orientation_color(val));
 }
 
+static const char *auto_eliminate_label(int val)
+{
+    return val ? "Auto\nElimination\nON" : "Auto\nElimination\nOFF";
+}
+
+static void event_screen_auto_eliminate(lv_event_t *e)
+{
+    int val;
+    (void)e;
+    val = !nvs_get_auto_eliminate();
+    nvs_set_auto_eliminate(val);
+    if (label_auto_eliminate_quad) {
+        lv_label_set_text(label_auto_eliminate_quad, auto_eliminate_label(val));
+    }
+    set_btn_color(btn_auto_eliminate, val ? TOGGLE_ON : TOGGLE_OFF);
+}
+
 static void event_screen_more(lv_event_t *e)
 {
     (void)e;
@@ -373,7 +392,7 @@ void build_quad_menus(void)
         {color_mode_label(nvs_get_color_mode()), event_screen_color_mode, true, LV_EVENT_CLICKED},
         {deselect_label(nvs_get_deselect_timeout()), event_screen_deselect, true, LV_EVENT_CLICKED},
         {orientation_mode_label(nvs_get_orientation()), event_screen_orientation, true, LV_EVENT_CLICKED},
-        {"",              NULL, false, LV_EVENT_CLICKED},
+        {auto_eliminate_label(nvs_get_auto_eliminate()), event_screen_auto_eliminate, true, LV_EVENT_CLICKED},
     };
     build_quad_screen(&screen_settings_page2, page2_items);
 
@@ -388,6 +407,10 @@ void build_quad_menus(void)
     btn_orientation = lv_obj_get_child(screen_settings_page2, 2);
     label_orientation_quad = lv_obj_get_child(btn_orientation, 0);
     set_btn_color(btn_orientation, orientation_color(nvs_get_orientation()));
+
+    btn_auto_eliminate = lv_obj_get_child(screen_settings_page2, 3);
+    label_auto_eliminate_quad = lv_obj_get_child(btn_auto_eliminate, 0);
+    set_btn_color(btn_auto_eliminate, nvs_get_auto_eliminate() ? TOGGLE_ON : TOGGLE_OFF);
 }
 
 void build_settings_screen(void)

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -13,6 +13,7 @@ static int cached_orientation = ORIENTATION_MODE_ABSOLUTE;
 static int cached_num_players = 4;
 static int cached_players_to_track = 1;
 static int cached_life_total = DEFAULT_LIFE_TOTAL;
+static int cached_auto_eliminate = 1; /* 1=ON (default), 0=OFF */
 static char cached_name_list[NAME_LIST_COUNT][NAME_LIST_LEN];
 
 // ---------- init ----------
@@ -54,6 +55,10 @@ void knob_nvs_init(void)
         cached_num_players = (np_val < 1) ? 1 : (np_val > MAX_PLAYERS) ? MAX_PLAYERS : np_val;
         cached_players_to_track = (pt_val < 1) ? 1 : (pt_val > 4) ? 4 : pt_val;
         cached_life_total = (lt_val < 0) ? 0 : (lt_val > LIFE_MAX) ? LIFE_MAX : lt_val;
+
+        int8_t ae_val = 1;
+        nvs_get_i8(handle, "auto_elim", &ae_val);
+        cached_auto_eliminate = (ae_val != 0) ? 1 : 0;
 
         size_t nl_size = sizeof(cached_name_list);
         nvs_get_blob(handle, "name_list", cached_name_list, &nl_size);
@@ -159,6 +164,18 @@ void nvs_set_life_total(int value)
     settings_dirty = true;
 }
 
+// ---------- auto-eliminate ----------
+int nvs_get_auto_eliminate(void)
+{
+    return cached_auto_eliminate;
+}
+
+void nvs_set_auto_eliminate(int value)
+{
+    cached_auto_eliminate = (value != 0) ? 1 : 0;
+    settings_dirty = true;
+}
+
 // ---------- name list ----------
 void nvs_get_name_list(char (*out)[NAME_LIST_LEN])
 {
@@ -185,6 +202,7 @@ void settings_save(void)
         nvs_set_i8(handle, "num_players", (int8_t)cached_num_players);
         nvs_set_i8(handle, "track", (int8_t)cached_players_to_track);
         nvs_set_i16(handle, "life_total", (int16_t)cached_life_total);
+        nvs_set_i8(handle, "auto_elim", (int8_t)cached_auto_eliminate);
         nvs_set_blob(handle, "name_list", cached_name_list, sizeof(cached_name_list));
         nvs_commit(handle);
         nvs_close(handle);

--- a/knobby/src/storage.h
+++ b/knobby/src/storage.h
@@ -25,6 +25,9 @@ void nvs_set_players_to_track(int value);
 int nvs_get_life_total(void);
 void nvs_set_life_total(int value);
 
+int nvs_get_auto_eliminate(void);
+void nvs_set_auto_eliminate(int value);
+
 #define NAME_LIST_COUNT 10
 #define NAME_LIST_LEN   16
 void nvs_get_name_list(char (*out)[NAME_LIST_LEN]);

--- a/knobby/src/types.h
+++ b/knobby/src/types.h
@@ -20,9 +20,11 @@
 #define KNOB_EVENT_QUEUE_SIZE 32
 
 // ---------- color modes ----------
-#define COLOR_MODE_PLAYER 0
-#define COLOR_MODE_LIFE   1
-#define COLOR_MODE_COUNT  2
+#define COLOR_MODE_PLAYER     0
+#define COLOR_MODE_LIFE       1
+#define COLOR_MODE_COUNT      2
+
+#define CUSTOM_COLOR_COUNT 18
 
 // ---------- orientation modes ----------
 #define ORIENTATION_MODE_ABSOLUTE 0

--- a/knobby/src/ui_1p.c
+++ b/knobby/src/ui_1p.c
@@ -42,7 +42,7 @@ static lv_obj_t *label_damage_hint = NULL;
 static void refresh_ring(void)
 {
     int max_life = nvs_get_life_total();
-    lv_color_t c = get_life_color(player_life[0], max_life);
+    lv_color_t c = get_effective_player_color(0, 0, LIFE_VIB_MID);
 
     lv_arc_set_range(arc_life, 0, max_life);
     lv_arc_set_value(arc_life, get_arc_display_value(player_life[0], max_life));
@@ -111,7 +111,7 @@ static void refresh_life_digits(void)
         else
             snprintf(buf, sizeof(buf), "%d", display_value);
     } else {
-        c = get_life_color(display_value, nvs_get_life_total());
+        c = get_effective_player_color(0, 0, LIFE_VIB_MID);
         snprintf(buf, sizeof(buf), "%d", display_value);
     }
 

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -244,18 +244,11 @@ static lv_color_t refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t
     lv_color_t bg_color;
     lv_color_t text_color;
 
-    if (nvs_get_color_mode() == COLOR_MODE_LIFE) {
-        int tier = get_life_tier(player_life[i], nvs_get_life_total());
+    {
         int vib;
         if (selected_player < 0) vib = LIFE_VIB_MID;
         else vib = selected ? LIFE_VIB_VIV : LIFE_VIB_DIM;
-        bg_color = get_life_color_vib(tier, vib);
-        text_color = color_is_light(bg_color) ? lv_color_black() : lv_color_white();
-    } else {
-        int vib;
-        if (selected_player < 0) vib = LIFE_VIB_MID;
-        else vib = selected ? LIFE_VIB_VIV : LIFE_VIB_DIM;
-        bg_color = get_player_color_vib(color_i, vib);
+        bg_color = get_effective_player_color(i, color_i, vib);
         text_color = color_is_light(bg_color) ? lv_color_black() : lv_color_white();
     }
 
@@ -278,14 +271,15 @@ static lv_color_t refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t
             lv_label_set_text(life_lbl, buf);
             {
                 lv_color_t preview_c;
-                if (nvs_get_color_mode() == COLOR_MODE_LIFE) {
-                    preview_c = color_is_light(bg_color) ? lv_color_black() : lv_color_white();
-                } else {
+                if (nvs_get_color_mode() == COLOR_MODE_PLAYER && !player_has_override[i]) {
                     preview_c = get_player_preview_color(color_i, pending_life_delta);
                     if (color_is_light(bg_color) && color_is_light(preview_c))
                         preview_c = lv_color_black();
                     else if (!color_is_light(bg_color) && !color_is_light(preview_c))
                         preview_c = lv_color_white();
+                } else {
+                    /* Life mode, or player has override: pick purely on bg contrast */
+                    preview_c = color_is_light(bg_color) ? lv_color_black() : lv_color_white();
                 }
                 lv_obj_set_style_text_color(life_lbl, preview_c, 0);
             }
@@ -691,3 +685,4 @@ void build_multiplayer_3p_screen(void)
             &counter_value_3p[i][COUNTER_TYPE_EXPERIENCE], p);
     }
 }
+

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -12,6 +12,8 @@ lv_obj_t *screen_player_all_damage = NULL;
 lv_obj_t *screen_counter_menu = NULL;
 lv_obj_t *screen_counter_edit = NULL;
 lv_obj_t *screen_eliminated_player_menu = NULL;
+lv_obj_t *screen_player_color_menu = NULL;
+lv_obj_t *screen_player_color_picker = NULL;
 
 // ---------- widgets ----------
 static lv_obj_t *label_all_damage_title = NULL;
@@ -193,20 +195,89 @@ static void event_counter_apply(lv_event_t *e)
     back_to_main();
 }
 
+// ---------- per-player color ----------
+static lv_obj_t *color_picker_swatch = NULL;
+static lv_obj_t *color_picker_name_label = NULL;
+static lv_obj_t *color_picker_title_label = NULL;
+static int color_picker_index = 0;
+
+static void event_menu_color(lv_event_t *e)
+{
+    (void)e;
+    load_screen_if_needed(screen_player_color_menu);
+}
+
+static void event_color_default(lv_event_t *e)
+{
+    (void)e;
+    player_has_override[menu_player] = false;
+    player_life_color[menu_player] = false;
+    refresh_player_ui();
+    back_to_main();
+}
+
+static void event_color_life(lv_event_t *e)
+{
+    (void)e;
+    player_has_override[menu_player] = true;
+    player_life_color[menu_player] = true;
+    refresh_player_ui();
+    back_to_main();
+}
+
+static void event_color_custom(lv_event_t *e)
+{
+    char title_buf[32];
+    (void)e;
+    color_picker_index = player_color_index[menu_player];
+    if (color_picker_title_label != NULL) {
+        snprintf(title_buf, sizeof(title_buf), "%s\nColor", player_names[menu_player]);
+        lv_label_set_text(color_picker_title_label, title_buf);
+    }
+    if (color_picker_swatch != NULL)
+        lv_obj_set_style_bg_color(color_picker_swatch, get_custom_color_vib(color_picker_index, LIFE_VIB_MID), 0);
+    if (color_picker_name_label != NULL)
+        lv_label_set_text(color_picker_name_label, get_custom_color_name(color_picker_index));
+    load_screen_if_needed(screen_player_color_picker);
+}
+
+void change_player_color(int delta)
+{
+    color_picker_index += delta;
+    if (color_picker_index < 0) color_picker_index = CUSTOM_COLOR_COUNT - 1;
+    if (color_picker_index >= CUSTOM_COLOR_COUNT) color_picker_index = 0;
+
+    if (color_picker_swatch != NULL)
+        lv_obj_set_style_bg_color(color_picker_swatch, get_custom_color_vib(color_picker_index, LIFE_VIB_MID), 0);
+    if (color_picker_name_label != NULL)
+        lv_label_set_text(color_picker_name_label, get_custom_color_name(color_picker_index));
+}
+
+void commit_player_color(void)
+{
+    player_has_override[menu_player] = true;
+    player_color_index[menu_player] = color_picker_index;
+    player_life_color[menu_player] = false;
+    refresh_player_ui();
+}
+
+static void event_color_apply(lv_event_t *e)
+{
+    (void)e;
+    commit_player_color();
+    back_to_main();
+}
+
 // ---------- screen builders ----------
 void build_player_menu_screen(void)
 {
     quad_item_t items[4] = {
-        {"Rename",      event_menu_rename,     true,  LV_EVENT_CLICKED},
+        {"Name/\nColor", event_menu_color,     true,  LV_EVENT_CLICKED},
         {"Commander\nDamage", event_menu_cmd_damage, true,  LV_EVENT_CLICKED},
         {"All\nDamage", event_menu_all_damage, true,  LV_EVENT_CLICKED},
         {"Counters",    event_menu_counters,   true,  LV_EVENT_SHORT_CLICKED},
     };
     build_quad_screen(&screen_player_menu, items);
-
-    /* Long-press Rename to rename all players sequentially */
-    lv_obj_t *rename_btn = lv_obj_get_child(screen_player_menu, 0);
-    lv_obj_add_event_cb(rename_btn, event_menu_rename_all, LV_EVENT_LONG_PRESSED, NULL);
 
     /* Long-press Counters to manually eliminate */
     lv_obj_t *counters_btn = lv_obj_get_child(screen_player_menu, 3);
@@ -334,5 +405,63 @@ void build_counter_edit_screen(void)
     lv_obj_align(label_counter_edit_hint, LV_ALIGN_CENTER, 0, 34);
 
     btn = make_button(screen_counter_edit, "Apply", 120, 46, event_counter_apply);
+    lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
+}
+
+// ---------- per-player color screens ----------
+void build_player_color_menu_screen(void)
+{
+    quad_item_t items[4] = {
+        {"Rename",          event_menu_rename,   true, LV_EVENT_SHORT_CLICKED},
+        {"Default\nSetting", event_color_default, true, LV_EVENT_CLICKED},
+        {"Life\nColor",     event_color_life,    true, LV_EVENT_CLICKED},
+        {"Custom\nColor",   event_color_custom,  true, LV_EVENT_CLICKED},
+    };
+    build_quad_screen(&screen_player_color_menu, items);
+
+    /* Long-press Rename to rename all players sequentially */
+    lv_obj_t *name_btn = lv_obj_get_child(screen_player_color_menu, 0);
+    lv_obj_add_event_cb(name_btn, event_menu_rename_all, LV_EVENT_LONG_PRESSED, NULL);
+}
+
+void build_player_color_picker_screen(void)
+{
+    lv_obj_t *hint;
+
+    screen_player_color_picker = lv_obj_create(NULL);
+    lv_obj_set_size(screen_player_color_picker, 360, 360);
+    lv_obj_set_style_bg_color(screen_player_color_picker, lv_color_black(), 0);
+    lv_obj_set_style_border_width(screen_player_color_picker, 0, 0);
+    lv_obj_set_scrollbar_mode(screen_player_color_picker, LV_SCROLLBAR_MODE_OFF);
+
+    color_picker_title_label = lv_label_create(screen_player_color_picker);
+    lv_label_set_text(color_picker_title_label, "Color");
+    lv_obj_set_style_text_color(color_picker_title_label, lv_color_white(), 0);
+    lv_obj_set_style_text_font(color_picker_title_label, &lv_font_montserrat_22, 0);
+    lv_obj_set_style_text_align(color_picker_title_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(color_picker_title_label, LV_ALIGN_TOP_MID, 0, 20);
+
+    color_picker_swatch = lv_obj_create(screen_player_color_picker);
+    lv_obj_remove_style_all(color_picker_swatch);
+    lv_obj_set_size(color_picker_swatch, 120, 120);
+    lv_obj_align(color_picker_swatch, LV_ALIGN_CENTER, 0, -15);
+    lv_obj_set_style_radius(color_picker_swatch, 12, 0);
+    lv_obj_set_style_bg_opa(color_picker_swatch, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(color_picker_swatch, get_custom_color_vib(0, LIFE_VIB_MID), 0);
+    lv_obj_clear_flag(color_picker_swatch, LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_CLICKABLE);
+
+    color_picker_name_label = lv_label_create(screen_player_color_picker);
+    lv_label_set_text(color_picker_name_label, get_custom_color_name(0));
+    lv_obj_set_style_text_color(color_picker_name_label, lv_color_white(), 0);
+    lv_obj_set_style_text_font(color_picker_name_label, &lv_font_montserrat_16, 0);
+    lv_obj_align(color_picker_name_label, LV_ALIGN_CENTER, 0, 54);
+
+    hint = lv_label_create(screen_player_color_picker);
+    lv_label_set_text(hint, "Turn knob, then apply");
+    lv_obj_set_style_text_color(hint, lv_color_hex(0x7A7A7A), 0);
+    lv_obj_set_style_text_font(hint, &lv_font_montserrat_14, 0);
+    lv_obj_align(hint, LV_ALIGN_CENTER, 0, 73);
+
+    lv_obj_t *btn = make_button(screen_player_color_picker, "Apply", 120, 46, event_color_apply);
     lv_obj_align(btn, LV_ALIGN_BOTTOM_MID, 0, -46);
 }

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -200,7 +200,7 @@ void build_player_menu_screen(void)
         {"Rename",      event_menu_rename,     true,  LV_EVENT_CLICKED},
         {"Commander\nDamage", event_menu_cmd_damage, true,  LV_EVENT_CLICKED},
         {"All\nDamage", event_menu_all_damage, true,  LV_EVENT_CLICKED},
-        {"Counters",    event_menu_counters,   true,  LV_EVENT_CLICKED},
+        {"Counters",    event_menu_counters,   true,  LV_EVENT_SHORT_CLICKED},
     };
     build_quad_screen(&screen_player_menu, items);
 

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -131,7 +131,18 @@ static void event_menu_counters(lv_event_t *e)
 static void event_eliminated_undo(lv_event_t *e)
 {
     (void)e;
-    undo_elimination_action(menu_player);
+    if (elimination_action_available(menu_player)) {
+        undo_elimination_action(menu_player);
+    } else {
+        manual_uneliminate_player(menu_player);
+    }
+    back_to_main();
+}
+
+static void event_menu_eliminate(lv_event_t *e)
+{
+    (void)e;
+    manual_eliminate_player(menu_player);
     back_to_main();
 }
 
@@ -196,6 +207,10 @@ void build_player_menu_screen(void)
     /* Long-press Rename to rename all players sequentially */
     lv_obj_t *rename_btn = lv_obj_get_child(screen_player_menu, 0);
     lv_obj_add_event_cb(rename_btn, event_menu_rename_all, LV_EVENT_LONG_PRESSED, NULL);
+
+    /* Long-press Counters to manually eliminate */
+    lv_obj_t *counters_btn = lv_obj_get_child(screen_player_menu, 3);
+    lv_obj_add_event_cb(counters_btn, event_menu_eliminate, LV_EVENT_LONG_PRESSED, NULL);
 }
 
 void build_eliminated_player_menu_screen(void)

--- a/knobby/src/ui_player_menu.h
+++ b/knobby/src/ui_player_menu.h
@@ -9,6 +9,8 @@ extern lv_obj_t *screen_player_all_damage;
 extern lv_obj_t *screen_counter_menu;
 extern lv_obj_t *screen_counter_edit;
 extern lv_obj_t *screen_eliminated_player_menu;
+extern lv_obj_t *screen_player_color_menu;
+extern lv_obj_t *screen_player_color_picker;
 
 // ---------- functions ----------
 void build_player_menu_screen(void);
@@ -16,11 +18,15 @@ void build_eliminated_player_menu_screen(void);
 void build_all_damage_screen(void);
 void build_counter_menu_screen(void);
 void build_counter_edit_screen(void);
+void build_player_color_menu_screen(void);
+void build_player_color_picker_screen(void);
 
 void refresh_all_damage_ui(void);
 void refresh_counter_edit_ui(void);
 
 void open_player_menu(int player_index);
 void open_counter_menu(void);
+void change_player_color(int delta);
+void commit_player_color(void);
 
 #endif // _UI_PLAYER_MENU_H

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -9,24 +9,33 @@ LLVM_BIN  ?=
 LVGL_PATH ?= $(HOME)/Arduino/libraries/lvgl
 PYTHON    ?= python3
 
-SDL2_ROOT := SDL2/x86_64-w64-mingw32
-
 KNOBBY    := ../knobby
 BUILD     := build
 BIN       := knobby_sim
-BIN_GUI   := knobby_sim_gui.exe
 
-CC        := $(LLVM_BIN)/clang.exe
-SDL_CFLAGS := -I$(SDL2_ROOT)/include
-SDL_LDFLAGS := -L$(SDL2_ROOT)/lib -lSDL2main -lSDL2
+ifeq ($(OS),Windows_NT)
+    SDL2_ROOT   := SDL2/x86_64-w64-mingw32
+    BIN_GUI     := knobby_sim_gui.exe
+    CC          ?= $(LLVM_BIN)/clang.exe
+    SDL_CFLAGS  := -I$(SDL2_ROOT)/include
+    SDL_LDFLAGS := -L$(SDL2_ROOT)/lib -lSDL2main -lSDL2
+else
+    BIN_GUI     := knobby_sim_gui
+    CC          ?= gcc
+    SDL_CFLAGS  := $(shell pkg-config --cflags sdl2 2>/dev/null)
+    SDL_LDFLAGS := $(shell pkg-config --libs sdl2 2>/dev/null || echo "-lSDL2")
+endif
 
 CFLAGS    := -Wall -Wno-unused-function \
              -DLV_CONF_INCLUDE_SIMPLE -DSIMULATOR=1 \
              -I. -Iesp_stubs -I$(LVGL_PATH) -I$(LVGL_PATH)/src -I$(KNOBBY) -I$(KNOBBY)/src \
-             $(SDL_CFLAGS) \
              -O2 -g
 
-LDFLAGS   := $(SDL_LDFLAGS) -lm
+LDFLAGS   := -lm
+
+# SDL2 flags are only used for the GUI build, not the headless screenshot simulator
+GUI_CFLAGS  := $(CFLAGS) $(SDL_CFLAGS)
+GUI_LDFLAGS := $(SDL_LDFLAGS) $(LDFLAGS)
 
 # ---- Source files ----
 
@@ -70,7 +79,7 @@ gui: $(BIN_GUI)
 	./$(BIN_GUI)
 
 $(BIN_GUI): $(ALL_OBJS_GUI)
-	$(CC) $(ALL_OBJS_GUI) -o $@ $(LDFLAGS)
+	$(CC) $(ALL_OBJS_GUI) -o $@ $(GUI_LDFLAGS)
 
 web:
 	$(PYTHON) gen_web_sources.py $(LVGL_PATH) $(KNOBBY)
@@ -80,7 +89,7 @@ web:
 		-s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 
 screenshot: $(BIN)
-	@if not exist screenshots mkdir screenshots
+	@mkdir -p screenshots
 	./$(BIN) $(ARGS)
 
 generate-matrix: $(BIN)
@@ -92,11 +101,20 @@ clean:
 # ---- Build rules ----
 
 $(BUILD):
-	@if not exist $(BUILD) mkdir $(BUILD)
+	@mkdir -p $(BUILD)
 
 define compile_rule
 $(call obj_name,$(1)): $(1) | $(BUILD)
 	$(CC) $(CFLAGS) -c $$< -o $$@
 endef
 
-$(foreach src,$(sort $(ALL_SRCS) $(ALL_SRCS_GUI)),$(eval $(call compile_rule,$(src))))
+# GUI-only sources (sim_sdl2.c) need SDL2 include paths
+define gui_compile_rule
+$(call obj_name,$(1)): $(1) | $(BUILD)
+	$(CC) $(GUI_CFLAGS) -c $$< -o $$@
+endef
+
+GUI_ONLY_SRCS := $(filter-out $(ALL_SRCS),$(ALL_SRCS_GUI))
+
+$(foreach src,$(ALL_SRCS),$(eval $(call compile_rule,$(src))))
+$(foreach src,$(GUI_ONLY_SRCS),$(eval $(call gui_compile_rule,$(src))))

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -21,7 +21,7 @@ shot() {
 # ============================================================
 # 1. Life preview deltas — 1p mode
 # ============================================================
-for delta in +444 -444 +12 -12 +1 -1; do
+for delta in +444 -444 +1; do
     tag=$(echo "$delta" | tr '+' 'p' | tr '-' 'n')
     shot "1p_preview_${tag}.png" --screen 1p --track 1 \
         --preview-delta "$delta" --preview-player -1
@@ -30,63 +30,75 @@ done
 # ============================================================
 # 2. Life preview deltas — multiplayer modes × orientations
 # ============================================================
+# Worst-case (+444) in every quadrant × orientation to catch overlap/clipping
 for track in 2 3 4; do
     max_player=$((track - 1))
     for orient in 0 1 2; do
         orient_name=("absolute" "centric" "tabletop")
         oname=${orient_name[$orient]}
         for player in $(seq 0 $max_player); do
-            for delta in +444 -444 +12 -12 +1 -1; do
-                tag=$(echo "$delta" | tr '+' 'p' | tr '-' 'n')
-                shot "${track}p_${oname}_p${player}_preview_${tag}.png" \
-                    --screen ${track}p --track "$track" --orientation "$orient" \
-                    --preview-delta "$delta" --preview-player "$player"
-            done
+            shot "${track}p_${oname}_p${player}_preview_p444.png" \
+                --screen ${track}p --track "$track" --orientation "$orient" \
+                --preview-delta +444 --preview-player "$player"
         done
+    done
+done
+# Remaining deltas for player 0 at absolute orientation (formatting coverage)
+for track in 2 3 4; do
+    for delta in -444 +1 -1 +12 -12; do
+        tag=$(echo "$delta" | tr '+' 'p' | tr '-' 'n')
+        shot "${track}p_absolute_p0_preview_${tag}.png" \
+            --screen ${track}p --track "$track" --orientation 0 \
+            --preview-delta "$delta" --preview-player 0
     done
 done
 
 # ============================================================
 # 3. Life totals at specific values — all player modes × orientations
 # ============================================================
-for life in 0 20 40 444; do
-    # 1p
-    shot "1p_life${life}.png" --screen 1p --track 1 \
-        --starting-life "$life" --life "$life"
+# All life values at one orientation (color tier coverage)
+for life in -5 0 20 40 444; do
+    ltag=$life
+    [ "$life" -lt 0 ] && ltag="n${life#-}"
+    shot "1p_life${ltag}.png" --screen 1p --track 1 \
+        --starting-life 40 --life "$life"
 
     # multiplayer — player colors
     for track in 2 3 4; do
         life_csv=$(printf "%s" "$life"; for j in $(seq 2 $track); do printf ",%s" "$life"; done)
-        for orient in 0 1 2; do
+        shot "${track}p_absolute_life${ltag}.png" \
+            --screen ${track}p --track "$track" --orientation 0 \
+            --starting-life 40 --life "$life_csv"
+    done
+done
+# Worst-case widths (444, -5) across all orientations for clipping detection
+for life in -5 444; do
+    ltag=$life
+    [ "$life" -lt 0 ] && ltag="n${life#-}"
+    for track in 2 3 4; do
+        life_csv=$(printf "%s" "$life"; for j in $(seq 2 $track); do printf ",%s" "$life"; done)
+        for orient in 1 2; do
             orient_name=("absolute" "centric" "tabletop")
             oname=${orient_name[$orient]}
-            shot "${track}p_${oname}_life${life}.png" \
+            shot "${track}p_${oname}_life${ltag}.png" \
                 --screen ${track}p --track "$track" --orientation "$orient" \
-                --starting-life "$life" --life "$life_csv"
+                --starting-life 40 --life "$life_csv"
         done
     done
 done
 
 # ============================================================
-# 4. Life-color mode — multiplayer × orientations × varied life
+# 4. Life-color mode — multiplayer × orientations × mixed life
 # ============================================================
 for track in 2 3 4; do
+    case "$track" in
+        2) life_csv="5,35" ;;
+        3) life_csv="5,20,35" ;;
+        4) life_csv="5,15,35,50" ;;
+    esac
     for orient in 0 1 2; do
         orient_name=("absolute" "centric" "tabletop")
         oname=${orient_name[$orient]}
-
-        # All at 40 (green)
-        life_csv=$(printf "40"; for j in $(seq 2 $track); do printf ",40"; done)
-        shot "${track}p_${oname}_lifecolor_40.png" \
-            --screen ${track}p --track "$track" --orientation "$orient" \
-            --color-mode 1 --starting-life 40 --life "$life_csv"
-
-        # Mixed: each player at a different tier
-        case "$track" in
-            2) life_csv="5,35" ;;
-            3) life_csv="5,20,35" ;;
-            4) life_csv="5,15,35,50" ;;
-        esac
         shot "${track}p_${oname}_lifecolor_mixed.png" \
             --screen ${track}p --track "$track" --orientation "$orient" \
             --color-mode 1 --starting-life 40 --life "$life_csv"
@@ -94,18 +106,14 @@ for track in 2 3 4; do
 done
 
 # ============================================================
-# 5. Selected player (no preview) — multiplayer × orientations
+# 5. Selected player (no preview) — multiplayer, one orientation
 # ============================================================
 for track in 2 3 4; do
     max_player=$((track - 1))
-    for orient in 0 1 2; do
-        orient_name=("absolute" "centric" "tabletop")
-        oname=${orient_name[$orient]}
-        for player in $(seq 0 $max_player); do
-            shot "${track}p_${oname}_selected_p${player}.png" \
-                --screen ${track}p --track "$track" --orientation "$orient" \
-                --selected "$player"
-        done
+    for player in $(seq 0 $max_player); do
+        shot "${track}p_absolute_selected_p${player}.png" \
+            --screen ${track}p --track "$track" --orientation 0 \
+            --selected "$player"
     done
 done
 
@@ -220,11 +228,11 @@ shot "dice_$((RANDOM % 20 + 1)).png" --screen dice --dice $((RANDOM % 20 + 1))
 shot "damage_log_random.png" --screen damage-log --random-log
 
 # ============================================================
-# 19. Timer overlay — 1p mode at various life totals
+# 19. Timer overlay — 1p mode at worst-case life totals
 # ============================================================
-for life in 0 20 40 444; do
+for life in 0 444; do
     shot "1p_timer_life${life}.png" --screen 1p --track 1 \
-        --starting-life "$life" --life "$life" \
+        --starting-life 40 --life "$life" \
         --turn-number $((RANDOM % 31)) --turn-elapsed $((RANDOM % 21600 * 1000))
 done
 
@@ -295,7 +303,7 @@ for f in "${FILES[@]}"; do
         4p_*_preview_*)       SEC_4P_PREV+=("$f") ;;
         1p_timer_*)           SEC_TIMER+=("$f") ;;
         *_lifecolor_*)        SEC_LIFECOLOR+=("$f") ;;
-        *_life[0-9]*)         SEC_LIFE+=("$f") ;;
+        *_life[0-9n]*)        SEC_LIFE+=("$f") ;;
         *_selected_*)         SEC_SELECTED+=("$f") ;;
         *_counters.png)       SEC_COUNTERS+=("$f") ;;
         brightness_*)         SEC_BRIGHT+=("$f") ;;

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -63,6 +63,11 @@ for life in -5 0 20 40 444; do
     shot "1p_life${ltag}.png" --screen 1p --track 1 \
         --starting-life 40 --life "$life"
 
+    # 1p — custom color override
+    shot "1p_custom_life${ltag}.png" --screen 1p --track 1 \
+        --starting-life 40 --life "$life" \
+        --player-override 1,0,0,0 --player-colors 4,0,0,0
+
     # multiplayer — player colors
     for track in 2 3 4; do
         life_csv=$(printf "%s" "$life"; for j in $(seq 2 $track); do printf ",%s" "$life"; done)
@@ -170,7 +175,31 @@ shot "game_mode_2p_20.png" --screen game-mode --players 2 --track 2 --starting-l
 shot "game_mode_3p_30.png" --screen game-mode --players 3 --track 3 --starting-life 30
 
 # ============================================================
-# 13. Settings pages with different toggle states
+# 13. Per-player color mode
+# ============================================================
+for track in 2 3 4; do
+    for orient in 0 1 2; do
+        orient_name=("absolute" "centric" "tabletop")
+        oname=${orient_name[$orient]}
+        case "$track" in
+            2) colors="5,9";       overrides="1,1" ;;
+            3) colors="5,9,0";     overrides="1,1,0" ;;
+            4) colors="0,5,7,9";   overrides="0,1,1,1" ;;
+        esac
+        shot "${track}p_${oname}_perplayer.png" \
+            --screen ${track}p --track "$track" --orientation "$orient" \
+            --player-colors "$colors" --player-override "$overrides"
+    done
+done
+
+# ============================================================
+# 14. Color menu and picker screens
+# ============================================================
+shot "color_menu.png" --screen color-menu --menu-player 0
+shot "color_picker.png" --screen color-picker --menu-player 0
+
+# ============================================================
+# 15. Settings pages with different toggle states
 # ============================================================
 for dim in 0 1 2 3; do
     dim_name=("off" "15s" "30s" "60s")
@@ -290,7 +319,7 @@ write_section() {
 
 # Sort files into sections
 SEC_1P_PREV=(); SEC_2P_PREV=(); SEC_3P_PREV=(); SEC_4P_PREV=()
-SEC_LIFE=(); SEC_LIFECOLOR=(); SEC_SELECTED=(); SEC_COUNTERS=()
+SEC_LIFE=(); SEC_LIFECOLOR=(); SEC_PERPLAYER=(); SEC_SELECTED=(); SEC_COUNTERS=()
 SEC_BRIGHT=(); SEC_COUNTER_EDIT=(); SEC_DAMAGE=(); SEC_SETTINGS=()
 SEC_TIMER=()
 SEC_OTHER=()
@@ -303,6 +332,7 @@ for f in "${FILES[@]}"; do
         4p_*_preview_*)       SEC_4P_PREV+=("$f") ;;
         1p_timer_*)           SEC_TIMER+=("$f") ;;
         *_lifecolor_*)        SEC_LIFECOLOR+=("$f") ;;
+        *_perplayer*)         SEC_PERPLAYER+=("$f") ;;
         *_life[0-9n]*)        SEC_LIFE+=("$f") ;;
         *_selected_*)         SEC_SELECTED+=("$f") ;;
         *_counters.png)       SEC_COUNTERS+=("$f") ;;
@@ -321,6 +351,7 @@ write_section "4-Player Life Preview" "${SEC_4P_PREV[@]}"
 write_section "1-Player Timer Overlay" "${SEC_TIMER[@]}"
 write_section "Life Totals (Player Colors)" "${SEC_LIFE[@]}"
 write_section "Life Totals (Life Colors)" "${SEC_LIFECOLOR[@]}"
+write_section "Life Totals (Per-Player Colors)" "${SEC_PERPLAYER[@]}"
 write_section "Selected Player" "${SEC_SELECTED[@]}"
 write_section "Player Counters" "${SEC_COUNTERS[@]}"
 write_section "Brightness" "${SEC_BRIGHT[@]}"

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -171,14 +171,22 @@ done
 
 for cm in 0 1; do
     cm_name=("player" "life")
-    for dt in 0 1 2 3; do
-        dt_name=("never" "5s" "15s" "30s")
-        for rot in 0 1 2; do
-            rot_name=("absolute" "centric" "tabletop")
-            shot "settings_more_cm${cm_name[$cm]}_ds${dt_name[$dt]}_${rot_name[$rot]}.png" \
-                --screen settings-more --color-mode "$cm" --deselect "$dt" --orientation "$rot"
-        done
-    done
+    shot "settings_more_cm${cm_name[$cm]}.png" --screen settings-more --color-mode "$cm"
+done
+
+for dt in 0 1 2 3; do
+    dt_name=("never" "5s" "15s" "30s")
+    shot "settings_more_ds${dt_name[$dt]}.png" --screen settings-more --deselect "$dt"
+done
+
+for rot in 0 1 2; do
+    rot_name=("absolute" "centric" "tabletop")
+    shot "settings_more_orient_${rot_name[$rot]}.png" --screen settings-more --orientation "$rot"
+done
+
+for ae in 0 1; do
+    ae_name=("aeoff" "aeon")
+    shot "settings_more_${ae_name[$ae]}.png" --screen settings-more --auto-eliminate "$ae"
 done
 
 # ============================================================

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -142,6 +142,11 @@ static void nav_counter_edit(void) {
     refresh_counter_edit_ui();
     lv_scr_load(screen_counter_edit);
 }
+static void nav_color_menu(void)   { load_screen_if_needed(screen_player_color_menu); }
+static void nav_color_picker(void) {
+    player_color_index[menu_player] = 5;  /* show Orange as example */
+    load_screen_if_needed(screen_player_color_picker);
+}
 
 static const screen_entry_t all_screens[] = {
     {"main",          nav_main},
@@ -167,6 +172,8 @@ static const screen_entry_t all_screens[] = {
     {"all-damage",    nav_all_damage},
     {"counters-menu", nav_counters_menu},
     {"counter-edit",  nav_counter_edit},
+    {"color-menu",    nav_color_menu},
+    {"color-picker",  nav_color_picker},
     {NULL, NULL}
 };
 
@@ -190,7 +197,9 @@ static void print_usage(void)
            "  --preview-delta <n>    Pending life change to display (e.g. +12, -5)\n"
            "  --preview-player <n>   Which player shows the preview, -1=1p mode (default: -1)\n"
            "\nDisplay settings:\n"
-           "  --color-mode <n>       0=player colors, 1=life colors (default: 0)\n"
+           "  --color-mode <n>       0=player, 1=life (default: 0)\n"
+           "  --player-colors <csv>  Per-player custom color indices, e.g. 0,5,2,13\n"
+           "  --player-override <csv> Per-player override flags, e.g. 0,1,0,0\n"
            "  --orientation <n>      0=absolute, 1=centric, 2=tabletop (default: 0)\n"
            "  --brightness <n>       Brightness percent 1-100 (default: 30)\n"
            "  --auto-dim <n>         0=OFF, 1=15s, 2=30s, 3=60s (default: 0)\n"
@@ -300,6 +309,10 @@ int main(int argc, char *argv[])
     int all_damage_set = 0;
     int menu_player_val = 0;
     int menu_player_set = 0;
+    int player_color_values[MAX_PLAYERS] = {0, 1, 2, 3};
+    int player_colors_set = 0;
+    int player_override_values[MAX_PLAYERS] = {0, 0, 0, 0};
+    int player_override_set = 0;
     int brightness_val = 0;
     int brightness_set = 0;
     int do_random_counters = 0;
@@ -368,6 +381,12 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[i], "--menu-player") == 0 && i + 1 < argc) {
             menu_player_val = atoi(argv[++i]);
             menu_player_set = 1;
+        } else if (strcmp(argv[i], "--player-colors") == 0 && i + 1 < argc) {
+            parse_csv_ints(argv[++i], player_color_values, MAX_PLAYERS);
+            player_colors_set = 1;
+        } else if (strcmp(argv[i], "--player-override") == 0 && i + 1 < argc) {
+            parse_csv_ints(argv[++i], player_override_values, MAX_PLAYERS);
+            player_override_set = 1;
         } else if (strcmp(argv[i], "--battery-voltage") == 0 && i + 1 < argc) {
             sim_battery_voltage = (float)atof(argv[++i]);
         } else if (strcmp(argv[i], "--random-counters") == 0) {
@@ -453,6 +472,14 @@ int main(int argc, char *argv[])
         } \
         if (menu_player_set) { \
             menu_player = menu_player_val; \
+        } \
+        if (player_colors_set) { \
+            for (i = 0; i < MAX_PLAYERS; i++) \
+                player_color_index[i] = player_color_values[i]; \
+        } \
+        if (player_override_set) { \
+            for (i = 0; i < MAX_PLAYERS; i++) \
+                player_has_override[i] = (bool)player_override_values[i]; \
         } \
         if (do_random_counters) \
             populate_random_counters(); \

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -195,6 +195,7 @@ static void print_usage(void)
            "  --brightness <n>       Brightness percent 1-100 (default: 30)\n"
            "  --auto-dim <n>         0=OFF, 1=15s, 2=30s, 3=60s (default: 0)\n"
            "  --deselect <n>         0=never, 1=5s, 2=15s, 3=30s (default: 0)\n"
+           "  --auto-eliminate <n>   0=OFF, 1=ON (default: 1)\n"
            "\nSpecial state:\n"
            "  --dice <n>             Set dice roll result (1-20)\n"
            "  --counter-type <n>     Counter type for counter-edit: 0=cmd tax, 1=partner tax,\n"
@@ -345,6 +346,8 @@ int main(int argc, char *argv[])
             sim_nvs_preset_i8("auto_dim", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--deselect") == 0 && i + 1 < argc) {
             sim_nvs_preset_i8("desel_time", (int8_t)atoi(argv[++i]));
+        } else if (strcmp(argv[i], "--auto-eliminate") == 0 && i + 1 < argc) {
+            sim_nvs_preset_i8("auto_elim", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--dice") == 0 && i + 1 < argc) {
             dice_val = atoi(argv[++i]);
             dice_set = 1;


### PR DESCRIPTION
## Summary
- Add per-player color overrides on top of the global color mode (Player/Life)
- 18-color custom palette with knob-scrollable picker
- Global setting applies on boot; per-player overrides are runtime only (lost on reboot)
- Player menu now opens a Name/Color sub-menu with Rename, Default Setting, Life Color, and Custom Color
- 1p ring color respects per-player overrides
- Includes: Makefile Linux compat fix, names survive reset, auto-eliminate toggle, screenshot matrix optimization, long-press click fix

Closes #25

[PDF of Screenshots](https://github.com/user-attachments/files/26755222/scanned.pdf)

## Merge order
This branch includes cherry-picks from other open PRs (#60, #62) and the `auto-eliminate-toggle` branch. Merge those first, then rebase this before merging:
- #60 — Restore Linux compatibility in Makefiles
- #62 — Preserve player names across reset

## Test plan
- [x] Firmware compiles (63%)
- [x] Simulator builds and runs on Linux
- [x] `make generate-matrix` produces 157 screenshots
- [x] Global color mode toggle cycles between Player and Life (2 modes)
- [x] Per-player color picker works via player menu
- [x] Default Setting clears override, returns to global
- [x] Swipe-back from picker cancels without committing
- [x] Colors survive game reset, lost on reboot
- [x] Users with NVS color_mode=2 fall through safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)