### PR TITLE
Add bounds checking to NVS color_mode

### DIFF
--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -45,8 +45,8 @@ void knob_nvs_init(void)
         nvs_get_i8(handle, "track", &pt_val);
         nvs_get_i16(handle, "life_total", &lt_val);
 
-        cached_auto_dim = (dim_val < 0) ? 0 : (dim_val >= AUTO_DIM_COUNT) ? 0 : dim_val;
-        cached_color_mode = lc_val;
+        cached_auto_dim = (dim_val < 0) ? AUTO_DIM_OFF : (dim_val >= AUTO_DIM_COUNT) ? AUTO_DIM_OFF : dim_val;
+        cached_color_mode = (lc_val < 0) ? COLOR_MODE_PLAYER : (lc_val >= COLOR_MODE_COUNT) ? COLOR_MODE_PLAYER : lc_val;
         cached_deselect_timeout = (dt_val < 0) ? 0 : (dt_val > 3) ? 3 : dt_val;
         cached_orientation = (rot_val < 0) ? ORIENTATION_MODE_ABSOLUTE
                 : (rot_val >= ORIENTATION_MODE_COUNT) ? ORIENTATION_MODE_ABSOLUTE
@@ -89,9 +89,7 @@ void nvs_set_brightness(int value)
 
 void nvs_set_auto_dim(int value)
 {
-    cached_auto_dim = (value < 0) ? AUTO_DIM_OFF
-                    : (value >= AUTO_DIM_COUNT) ? AUTO_DIM_OFF
-                    : value;
+    cached_auto_dim = (value < 0) ? AUTO_DIM_OFF : (value >= AUTO_DIM_COUNT) ? AUTO_DIM_OFF : value;
     settings_dirty = true;
 }
 
@@ -102,7 +100,7 @@ int nvs_get_color_mode(void)
 
 void nvs_set_color_mode(int value)
 {
-    cached_color_mode = value;
+    cached_color_mode = (value < 0) ? COLOR_MODE_PLAYER : (value >= COLOR_MODE_COUNT) ? COLOR_MODE_PLAYER : value;
     settings_dirty = true;
 }
 


### PR DESCRIPTION
## Summary
- Add range validation to `color_mode` NVS read and setter — the only setting that was missing it
- Out-of-range values (e.g. from firmware downgrade) fall back to `COLOR_MODE_PLAYER`
- Replace bare `0` with `AUTO_DIM_OFF` in auto_dim validation for consistency

Closes #67

## Test plan
- [x] Verify color mode cycles correctly between Player and Life
- [x] Firmware downgrade with a future color_mode value should fall back to Player mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)