### PR TITLE
Support commander damage tracking for up to 8 players

### DIFF
--- a/knobby/src/damage_log.c
+++ b/knobby/src/damage_log.c
@@ -116,7 +116,9 @@ static void format_log_line(damage_log_entry_t *entry, char *buf, size_t buf_sz)
 
     format_elapsed(elapsed_s, time_str, sizeof(time_str));
 
-    if (entry->event_type == LOG_EVT_CMD_DAMAGE && entry->source >= 0) {
+    if (entry->event_type == LOG_EVT_CMD_DAMAGE && entry->source >= 0 &&
+        entry->source < MAX_GAME_PLAYERS && entry->player >= 0 &&
+        entry->player < MAX_GAME_PLAYERS) {
         snprintf(buf, buf_sz, "%s: %s dealt %d cmd to %s",
                  time_str,
                  player_names[entry->source],
@@ -132,7 +134,7 @@ static void format_log_line(damage_log_entry_t *entry, char *buf, size_t buf_sz)
                  action,
                  counter_name,
                  abs_delta);
-    } else if (entry->player >= 0 && entry->player < MAX_PLAYERS) {
+    } else if (entry->player >= 0 && entry->player < MAX_GAME_PLAYERS) {
         const char *action = entry->delta > 0 ? "gained" : "lost";
         snprintf(buf, buf_sz, "%s: %s %s %d life",
                  time_str, player_names[entry->player], action, abs_delta);

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -20,21 +20,23 @@ enemy_state_t enemies[MAX_ENEMY_COUNT] = {
 int selected_enemy = -1;
 int dice_result = 0;
 
-int player_life[MAX_PLAYERS] = {40, 40, 40, 40};
+int player_life[MAX_DISPLAY_PLAYERS] = {40, 40, 40, 40};
 int selected_player = -1;
-char player_names[MAX_PLAYERS][16] = {"P1", "P2", "P3", "P4"};
+char player_names[MAX_GAME_PLAYERS][16] = {
+    "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"
+};
 int menu_player = 0;
-int cmd_damage_totals[MAX_PLAYERS][MAX_PLAYERS] = {{0}};
+int cmd_damage_totals[MAX_GAME_PLAYERS][MAX_DISPLAY_PLAYERS] = {{0}};
 int all_damage_value = 0;
 int cmd_damage_target = -1;
 static int damage_start_value = 0;
 int pending_life_delta = 0;
 int preview_player = -1;
 bool life_preview_active = false;
-int player_counters[MAX_PLAYERS][COUNTER_TYPE_COUNT] = {{0}};
+int player_counters[MAX_DISPLAY_PLAYERS][COUNTER_TYPE_COUNT] = {{0}};
 counter_type_t counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
 int counter_edit_value = 0;
-bool player_eliminated[MAX_PLAYERS] = {false};
+bool player_eliminated[MAX_DISPLAY_PLAYERS] = {false};
 
 typedef struct {
     bool valid;
@@ -43,7 +45,7 @@ typedef struct {
     int delta;
 } elimination_action_t;
 
-static elimination_action_t elimination_action[MAX_PLAYERS] = {{0}};
+static elimination_action_t elimination_action[MAX_DISPLAY_PLAYERS] = {{0}};
 
 
 
@@ -63,13 +65,13 @@ static const counter_definition_t counter_definitions[COUNTER_TYPE_COUNT] = {
 
 static void clear_player_elimination_action(int player)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     elimination_action[player].valid = false;
 }
 
 static void set_player_elimination_action(int player, uint8_t event_type, int source, int delta)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     elimination_action[player].valid = true;
     elimination_action[player].event_type = event_type;
     elimination_action[player].source = source;
@@ -78,7 +80,7 @@ static void set_player_elimination_action(int player, uint8_t event_type, int so
 
 bool elimination_action_available(int player)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return false;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return false;
     return elimination_action[player].valid;
 }
 
@@ -101,7 +103,7 @@ void undo_elimination_action(int player)
 
 void check_player_elimination(int player)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     bool was_eliminated = player_eliminated[player];
     bool now_eliminated = false;
 
@@ -109,7 +111,7 @@ void check_player_elimination(int player)
         if (player_life[player] <= 0) {
             now_eliminated = true;
         } else {
-            for (int i = 0; i < MAX_PLAYERS; i++) {
+            for (int i = 0; i < MAX_GAME_PLAYERS; i++) {
                 if (i != player && cmd_damage_totals[i][player] >= 20) {
                     now_eliminated = true;
                     break;
@@ -133,7 +135,7 @@ void check_player_elimination(int player)
 
 void manual_eliminate_player(int player)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     if (player_eliminated[player]) return;
     player_eliminated[player] = true;
     clear_player_elimination_action(player);
@@ -142,7 +144,7 @@ void manual_eliminate_player(int player)
 
 void manual_uneliminate_player(int player)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     if (!player_eliminated[player]) return;
     player_eliminated[player] = false;
     clear_player_elimination_action(player);
@@ -150,12 +152,16 @@ void manual_uneliminate_player(int player)
 }
 
 // ---------- player colors ----------
-static const uint32_t player_color_table[MAX_PLAYERS][LIFE_VIB_COUNT] = {
+static const uint32_t player_color_table[MAX_GAME_PLAYERS][LIFE_VIB_COUNT] = {
     /*  dim        mid        vivid  */
     {0x024D3A, 0x06D6A0, 0x66FFD9},  /* P1 green  (bottom-left) */
     {0x2A0A4D, 0x7B1FE0, 0x9C4DFF},  /* P2 purple (top-left)    */
     {0x0A3A4D, 0x29B6F6, 0x4FC3F7},  /* P3 blue   (top-right)   */
     {0x4D4400, 0xFFD600, 0xFFEA61},  /* P4 yellow (bottom-right) */
+    {0x4D1C1C, 0xF44336, 0xFF5252},  /* P5 red    */
+    {0x4D3300, 0xFF9800, 0xFFB74D},  /* P6 orange */
+    {0x004D4D, 0x00BCD4, 0x4DD0E1},  /* P7 cyan   */
+    {0x3D0A4D, 0xE040FB, 0xEA80FC},  /* P8 pink   */
 };
 
 // ---------- custom color palette (18 colors) ----------
@@ -190,13 +196,13 @@ static const char *custom_color_names[CUSTOM_COLOR_COUNT] = {
 };
 
 // ---------- per-player color state (runtime only, lost on reboot) ----------
-int player_color_index[MAX_PLAYERS] = {0, 1, 2, 3};
-bool player_life_color[MAX_PLAYERS] = {false, false, false, false};
-bool player_has_override[MAX_PLAYERS] = {false, false, false, false};
+int player_color_index[MAX_DISPLAY_PLAYERS] = {0, 1, 2, 3};
+bool player_life_color[MAX_DISPLAY_PLAYERS] = {false, false, false, false};
+bool player_has_override[MAX_DISPLAY_PLAYERS] = {false, false, false, false};
 
 lv_color_t get_player_color_vib(int index, int vibrancy)
 {
-    if (index < 0 || index >= MAX_PLAYERS) return lv_color_hex(0x303030);
+    if (index < 0 || index >= MAX_GAME_PLAYERS) return lv_color_hex(0x303030);
     if (vibrancy < 0 || vibrancy >= LIFE_VIB_COUNT) vibrancy = LIFE_VIB_MID;
     return lv_color_hex(player_color_table[index][vibrancy]);
 }
@@ -213,7 +219,8 @@ lv_color_t get_player_active_color(int index)
 
 lv_color_t get_player_text_color(int index)
 {
-    return (index == 3) ? lv_color_black() : lv_color_white();
+    lv_color_t bg = get_player_base_color(index);
+    return color_is_light(bg) ? lv_color_black() : lv_color_white();
 }
 
 lv_color_t get_player_preview_color(int index, int delta)
@@ -324,7 +331,7 @@ bool counter_type_is_enabled(counter_type_t type)
 
 int get_counter_value(int player, counter_type_t type)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return 0;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return 0;
     if (type < 0 || type >= COUNTER_TYPE_COUNT) return 0;
 
     return player_counters[player][type];
@@ -332,7 +339,7 @@ int get_counter_value(int player, counter_type_t type)
 
 void begin_counter_edit(int player, counter_type_t type)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     if (type < 0 || type >= COUNTER_TYPE_COUNT) return;
 
     menu_player = player;
@@ -351,7 +358,7 @@ int apply_counter_edit(void)
     int old_value;
     int change_delta;
 
-    if (player < 0 || player >= MAX_PLAYERS) return 0;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return 0;
     if (counter_edit_type < 0 || counter_edit_type >= COUNTER_TYPE_COUNT) return 0;
 
     old_value = player_counters[player][counter_edit_type];
@@ -512,7 +519,7 @@ void change_all_damage(int delta)
 // ---------- undo ----------
 void undo_life_change(int player, int delta)
 {
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
 
     player_life[player] = clamp_life(player_life[player] - delta);
     check_player_elimination(player);
@@ -522,8 +529,8 @@ void undo_life_change(int player, int delta)
 
 void undo_cmd_damage(int source, int target, int delta)
 {
-    if (source < 0 || source >= MAX_PLAYERS) return;
-    if (target < 0 || target >= MAX_PLAYERS) return;
+    if (source < 0 || source >= MAX_GAME_PLAYERS) return;
+    if (target < 0 || target >= MAX_DISPLAY_PLAYERS) return;
     cmd_damage_totals[source][target] += delta;
     if (cmd_damage_totals[source][target] < 0)
         cmd_damage_totals[source][target] = 0;
@@ -533,7 +540,7 @@ void undo_cmd_damage(int source, int target, int delta)
 void undo_counter_change(int player, int counter_type, int delta)
 {
     if (counter_type < 0 || counter_type >= COUNTER_TYPE_COUNT) return;
-    if (player < 0 || player >= MAX_PLAYERS) return;
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
 
     player_counters[player][counter_type] = clamp_counter(
         player_counters[player][counter_type] - delta
@@ -565,7 +572,7 @@ void knob_life_reset(void)
         enemies[i].damage = 0;
     }
 
-    for (i = 0; i < MAX_PLAYERS; i++) {
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) {
         player_life[i] = starting_life;
     }
     selected_player = -1;
@@ -594,7 +601,7 @@ void knob_life_init(void)
     if (active_enemy_count < 0) active_enemy_count = 0;
     if (active_enemy_count > MAX_ENEMY_COUNT) active_enemy_count = MAX_ENEMY_COUNT;
 
-    for (i = 0; i < MAX_PLAYERS; i++) {
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) {
         player_life[i] = starting_life;
     }
     memset(player_counters, 0, sizeof(player_counters));

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -24,21 +24,21 @@ typedef struct {
 extern int active_enemy_count;
 extern enemy_state_t enemies[MAX_ENEMY_COUNT];
 extern int selected_enemy;
-extern int player_life[MAX_PLAYERS];
+extern int player_life[MAX_DISPLAY_PLAYERS];
 extern int selected_player;
-extern char player_names[MAX_PLAYERS][16];
+extern char player_names[MAX_GAME_PLAYERS][16];
 extern int menu_player;
-extern int cmd_damage_totals[MAX_PLAYERS][MAX_PLAYERS];
+extern int cmd_damage_totals[MAX_GAME_PLAYERS][MAX_DISPLAY_PLAYERS];
 extern int cmd_damage_target;
 extern int all_damage_value;
 extern int pending_life_delta;
 extern int preview_player;
 extern bool life_preview_active;
 extern int dice_result;
-extern int player_counters[MAX_PLAYERS][COUNTER_TYPE_COUNT];
+extern int player_counters[MAX_DISPLAY_PLAYERS][COUNTER_TYPE_COUNT];
 extern counter_type_t counter_edit_type;
 extern int counter_edit_value;
-extern bool player_eliminated[MAX_PLAYERS];
+extern bool player_eliminated[MAX_DISPLAY_PLAYERS];
 
 // ---------- functions ----------
 void knob_life_init(void);
@@ -69,9 +69,9 @@ void manual_uneliminate_player(int player);
 void check_player_elimination(int player);
 
 // ---------- player colors ----------
-extern int player_color_index[MAX_PLAYERS];
-extern bool player_life_color[MAX_PLAYERS];
-extern bool player_has_override[MAX_PLAYERS];
+extern int player_color_index[MAX_DISPLAY_PLAYERS];
+extern bool player_life_color[MAX_DISPLAY_PLAYERS];
+extern bool player_has_override[MAX_DISPLAY_PLAYERS];
 
 lv_color_t get_player_color_vib(int index, int vibrancy);
 lv_color_t get_player_base_color(int index);

--- a/knobby/src/game_mode.c
+++ b/knobby/src/game_mode.c
@@ -32,7 +32,7 @@ void refresh_game_mode_menu_ui(void)
     snprintf(buf, sizeof(buf), "Players\n%d", temp_num_players);
     lv_label_set_text(label_gm_num_players, buf);
 
-    max_track = temp_num_players < 4 ? temp_num_players : 4;
+    max_track = temp_num_players < MAX_DISPLAY_PLAYERS ? temp_num_players : MAX_DISPLAY_PLAYERS;
     if (temp_players_to_track > max_track) temp_players_to_track = max_track;
     snprintf(buf, sizeof(buf), "Track\n%d", temp_players_to_track);
     lv_label_set_text(label_gm_players_to_track, buf);
@@ -74,9 +74,9 @@ static void event_gm_num_players(lv_event_t *e)
     (void)e;
 
     temp_num_players++;
-    if (temp_num_players > MAX_PLAYERS) temp_num_players = 1;
+    if (temp_num_players > MAX_GAME_PLAYERS) temp_num_players = 1;
 
-    max_track = temp_num_players < 4 ? temp_num_players : 4;
+    max_track = temp_num_players < MAX_DISPLAY_PLAYERS ? temp_num_players : MAX_DISPLAY_PLAYERS;
     if (temp_players_to_track > max_track) temp_players_to_track = max_track;
 
     refresh_game_mode_menu_ui();
@@ -87,7 +87,7 @@ static void event_gm_players_to_track(lv_event_t *e)
     int max_track;
     (void)e;
 
-    max_track = temp_num_players < 4 ? temp_num_players : 4;
+    max_track = temp_num_players < MAX_DISPLAY_PLAYERS ? temp_num_players : MAX_DISPLAY_PLAYERS;
     temp_players_to_track++;
     if (temp_players_to_track > max_track) temp_players_to_track = 1;
 

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -52,8 +52,8 @@ void knob_nvs_init(void)
                 : (rot_val >= ORIENTATION_MODE_COUNT) ? ORIENTATION_MODE_ABSOLUTE
                                    : rot_val;
         cached_brightness = clamp_brightness(bri_val);
-        cached_num_players = (np_val < 1) ? 1 : (np_val > MAX_PLAYERS) ? MAX_PLAYERS : np_val;
-        cached_players_to_track = (pt_val < 1) ? 1 : (pt_val > 4) ? 4 : pt_val;
+        cached_num_players = (np_val < 1) ? 1 : (np_val > MAX_GAME_PLAYERS) ? MAX_GAME_PLAYERS : np_val;
+        cached_players_to_track = (pt_val < 1) ? 1 : (pt_val > MAX_DISPLAY_PLAYERS) ? MAX_DISPLAY_PLAYERS : pt_val;
         cached_life_total = (lt_val < 0) ? 0 : (lt_val > LIFE_MAX) ? LIFE_MAX : lt_val;
 
         int8_t ae_val = 1;
@@ -138,7 +138,7 @@ int nvs_get_num_players(void)
 
 void nvs_set_num_players(int value)
 {
-    cached_num_players = (value < 1) ? 1 : (value > MAX_PLAYERS) ? MAX_PLAYERS : value;
+    cached_num_players = (value < 1) ? 1 : (value > MAX_GAME_PLAYERS) ? MAX_GAME_PLAYERS : value;
     settings_dirty = true;
 }
 
@@ -149,7 +149,7 @@ int nvs_get_players_to_track(void)
 
 void nvs_set_players_to_track(int value)
 {
-    cached_players_to_track = (value < 1) ? 1 : (value > 4) ? 4 : value;
+    cached_players_to_track = (value < 1) ? 1 : (value > MAX_DISPLAY_PLAYERS) ? MAX_DISPLAY_PLAYERS : value;
     settings_dirty = true;
 }
 

--- a/knobby/src/types.h
+++ b/knobby/src/types.h
@@ -7,8 +7,9 @@
 #include <string.h>
 
 // ---------- constants ----------
-#define MAX_ENEMY_COUNT 3
-#define MAX_PLAYERS 4
+#define MAX_GAME_PLAYERS 8
+#define MAX_DISPLAY_PLAYERS 4
+#define MAX_ENEMY_COUNT (MAX_GAME_PLAYERS - 1)
 #define LIFE_MIN -999
 #define LIFE_MAX 999
 #define COUNTER_MIN 0

--- a/knobby/src/ui_1p.c
+++ b/knobby/src/ui_1p.c
@@ -184,52 +184,81 @@ void refresh_player_ui(void)
         refresh_multiplayer_ui();
 }
 
-void refresh_select_ui(void)
+/* grid constants for select screen */
+#define SEL_BOX_W      100
+#define SEL_BOX_H       56
+#define SEL_BOX_GAP_X    6
+#define SEL_BOX_GAP_Y    6
+#define SEL_GRID_COLS    2
+
+static bool is_enemy_eliminated(int player_index)
+{
+    return (player_index >= 0 && player_index < MAX_DISPLAY_PLAYERS &&
+            player_eliminated[player_index]);
+}
+
+static void style_select_entry(int i, int player_index)
 {
     char buf[32];
+    lv_color_t text_color = get_player_text_color(player_index);
+    bool eliminated = is_enemy_eliminated(player_index);
+
+    lv_label_set_text(label_enemy_name[i], player_names[player_index]);
+    snprintf(buf, sizeof(buf), "%d", enemies[i].damage);
+    lv_label_set_text(label_enemy_damage[i], buf);
+
+    if (eliminated) {
+        lv_color_t disabled_bg = lv_color_hex(0x404040);
+        lv_color_t disabled_text = lv_color_hex(0x808080);
+        lv_obj_set_style_text_color(label_enemy_name[i], disabled_text, 0);
+        lv_obj_set_style_text_color(label_enemy_damage[i], disabled_text, 0);
+        lv_obj_set_style_bg_color(select_rows[i], disabled_bg, 0);
+        lv_obj_set_style_bg_opa(select_rows[i], LV_OPA_COVER, 0);
+        lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
+    } else {
+        lv_obj_set_style_text_color(label_enemy_name[i], text_color, 0);
+        lv_obj_set_style_text_color(label_enemy_damage[i], text_color, 0);
+        lv_obj_set_style_bg_color(select_rows[i], get_player_base_color(player_index), 0);
+        lv_obj_set_style_bg_opa(select_rows[i], LV_OPA_COVER, 0);
+        lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_add_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
+    }
+
+    lv_obj_set_style_text_font(label_enemy_name[i], &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_font(label_enemy_damage[i], &lv_font_montserrat_22, 0);
+    lv_obj_align(label_enemy_name[i], LV_ALIGN_TOP_MID, 0, 4);
+    lv_obj_align(label_enemy_damage[i], LV_ALIGN_BOTTOM_MID, 0, -4);
+}
+
+void refresh_select_ui(void)
+{
     int i;
     int n = active_enemy_count;
-    int row_h = 46;
-    int gap = 10;
-    int total_h;
-    int start_y;
-
-    if (n > 5) { row_h = 38; gap = 6; }
-    total_h = n * row_h + (n > 0 ? (n - 1) * gap : 0);
-    start_y = (260 - total_h) / 2;
+    int cols = (n <= 1) ? 1 : SEL_GRID_COLS;
+    int rows_needed = (n + cols - 1) / cols;
+    int grid_w = cols * SEL_BOX_W + (cols - 1) * SEL_BOX_GAP_X;
+    int grid_h = rows_needed * SEL_BOX_H + (rows_needed - 1) * SEL_BOX_GAP_Y;
+    int grid_x = (240 - grid_w) / 2;
+    int grid_y = (260 - grid_h) / 2;
 
     for (i = 0; i < MAX_ENEMY_COUNT; i++) {
         if (select_rows[i] == NULL) continue;
 
         if (i < n) {
+            int col = i % cols;
+            int row = i / cols;
+            int items_in_row = (row < n / cols) ? cols : (n % cols);
+            if (items_in_row == 0) items_in_row = cols;
+            int row_offset = (cols > 1 && items_in_row == 1) ? (SEL_BOX_W + SEL_BOX_GAP_X) / 2 : 0;
+            int x = grid_x + col * (SEL_BOX_W + SEL_BOX_GAP_X) + row_offset;
+            int y = grid_y + row * (SEL_BOX_H + SEL_BOX_GAP_Y);
             int player_index = get_cmd_target_player_index(i);
-            lv_color_t text_color = get_player_text_color(player_index);
 
             lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_HIDDEN);
-            lv_obj_set_size(select_rows[i], 220, row_h);
-            lv_obj_set_pos(select_rows[i], 0, start_y + i * (row_h + gap));
-
-            lv_label_set_text(label_enemy_name[i], player_names[player_index]);
-            snprintf(buf, sizeof(buf), "%d", enemies[i].damage);
-            lv_label_set_text(label_enemy_damage[i], buf);
-
-            if (player_eliminated[player_index]) {
-                lv_color_t disabled_bg = lv_color_hex(0x404040);
-                lv_color_t disabled_text = lv_color_hex(0x808080);
-                lv_obj_set_style_text_color(label_enemy_name[i], disabled_text, 0);
-                lv_obj_set_style_text_color(label_enemy_damage[i], disabled_text, 0);
-                lv_obj_set_style_bg_color(select_rows[i], disabled_bg, 0);
-                lv_obj_set_style_bg_opa(select_rows[i], LV_OPA_COVER, 0);
-                lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
-            } else {
-                lv_obj_set_style_text_color(label_enemy_name[i], text_color, 0);
-                lv_obj_set_style_text_color(label_enemy_damage[i], text_color, 0);
-                lv_obj_set_style_bg_color(select_rows[i], get_player_base_color(player_index), 0);
-                lv_obj_set_style_bg_opa(select_rows[i], LV_OPA_COVER, 0);
-                lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_HIDDEN);
-                lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
-                lv_obj_add_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
-            }
+            lv_obj_set_size(select_rows[i], SEL_BOX_W, SEL_BOX_H);
+            lv_obj_set_pos(select_rows[i], x, y);
+            lv_obj_set_style_radius(select_rows[i], 8, 0);
+            style_select_entry(i, player_index);
         } else {
             lv_obj_add_flag(select_rows[i], LV_OBJ_FLAG_HIDDEN);
         }
@@ -300,7 +329,7 @@ static void event_select_enemy(lv_event_t *e)
 {
     int index = (int)(intptr_t)lv_event_get_user_data(e);
     int player_index = get_cmd_target_player_index(index);
-    if (player_index >= 0 && player_index < MAX_PLAYERS && player_eliminated[player_index]) {
+    if (player_index >= 0 && player_index < MAX_DISPLAY_PLAYERS && player_eliminated[player_index]) {
         return;
     }
     open_damage_screen(index);

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -84,7 +84,7 @@ static void create_counter_row(lv_obj_t *parent, counter_type_t type,
 
     *value_out = lv_label_create(row);
     lv_label_set_text(*value_out, "0");
-    lv_obj_set_style_text_color(*value_out, lv_color_white(), 0);
+    lv_obj_set_style_text_color(*value_out, get_player_text_color(player_index), 0);
     lv_obj_set_style_text_font(*value_out, &lv_font_montserrat_14, 0);
     lv_obj_align(*value_out, LV_ALIGN_BOTTOM_MID, 0, 0);
     lv_obj_set_style_text_align(*value_out, LV_TEXT_ALIGN_CENTER, 0);

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -125,14 +125,14 @@ done
 # ============================================================
 # 6. Random counters — multiplayer × orientations + 1p
 # ============================================================
-shot "1p_counters.png" --screen 1p --random-counters
+shot "1p_counters.png" --screen 1p --random-counters --auto-eliminate 0
 for track in 2 3 4; do
     for orient in 0 1 2; do
         orient_name=("absolute" "centric" "tabletop")
         oname=${orient_name[$orient]}
         shot "${track}p_${oname}_counters.png" \
             --screen ${track}p --track "$track" --orientation "$orient" \
-            --random-counters
+            --random-counters --auto-eliminate 0
     done
 done
 
@@ -156,12 +156,33 @@ done
 # ============================================================
 # 9. Damage screen with non-zero damage
 # ============================================================
-shot "damage_nonzero.png" --screen damage --enemy-damage 7,3,12
+shot "damage_nonzero.png" --screen damage --names Maya,Leah,Kyle \
+    --enemy-damage 7,3,12
 
 # ============================================================
 # 10. Select screen with accumulated commander damage
 # ============================================================
-shot "select_with_damage.png" --screen select --enemy-damage 14,6,21
+# 1-7 enemies (2-8 players)
+shot "select_2p.png" --screen select --players 2 --track 1 \
+    --names Maya,Leah --enemy-damage 9
+shot "select_3p.png" --screen select --players 3 --track 1 \
+    --names Maya,Leah,Kyle --enemy-damage 14,6
+shot "select_4p.png" --screen select --players 4 --track 4 \
+    --names Maya,Leah,Kyle,Devin --enemy-damage 14,6,21
+shot "select_5p.png" --screen select --players 5 --track 4 \
+    --names Maya,Leah,Kyle,Devin,Riku --enemy-damage 3,0,8,0
+shot "select_6p.png" --screen select --players 6 --track 4 \
+    --names Maya,Leah,Kyle,Devin,Riku,Sarah --enemy-damage 5,0,12,0,3
+shot "select_7p.png" --screen select --players 7 --track 4 \
+    --names Maya,Leah,Kyle,Devin,Riku,Sarah,Nolan \
+    --enemy-damage 5,0,12,0,3,0
+shot "select_8p.png" --screen select --players 8 --track 4 \
+    --names Maya,Leah,Kyle,Devin,Riku,Sarah,Nolan,Tomoko \
+    --enemy-damage 5,0,12,0,3,0,7
+# select screen with an eliminated player (Kyle at 0 life)
+shot "select_eliminated.png" --screen select --players 5 --track 4 \
+    --names Maya,Leah,Kyle,Devin,Riku --enemy-damage 3,0,21,0 \
+    --life 40,40,0,40 --auto-eliminate 1
 
 # ============================================================
 # 11. Custom-life with non-default value
@@ -173,6 +194,7 @@ shot "custom_life_123.png" --screen custom-life --starting-life 123
 # ============================================================
 shot "game_mode_2p_20.png" --screen game-mode --players 2 --track 2 --starting-life 20
 shot "game_mode_3p_30.png" --screen game-mode --players 3 --track 3 --starting-life 30
+shot "game_mode_8p_t4.png" --screen game-mode --players 8 --track 4 --starting-life 40
 
 # ============================================================
 # 13. Per-player color mode

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -187,9 +187,9 @@ static void print_usage(void)
            "  --outdir <path>        Output directory (default: screenshots)\n"
            "  --output <filename>    Output filename (overrides default naming)\n"
            "\nGame state:\n"
-           "  --life <p1,p2,p3,p4>  Set player life totals (default: starting-life for all)\n"
-           "  --names <p1,p2,p3,p4> Set player names (default: P1,P2,P3,P4)\n"
-           "  --players <n>          Number of players in the game, 1-4 (default: 4)\n"
+           "  --life <p1,p2,...>     Set player life totals (default: starting-life for all)\n"
+           "  --names <p1,p2,...>    Set player names (default: P1..P8)\n"
+           "  --players <n>          Number of players in the game, 1-8 (default: 4)\n"
            "  --track <n>            Players shown on screen, 1-4 (default: 4)\n"
            "  --starting-life <n>    Starting/max life total (default: 40)\n"
            "  --selected <n>         Which player is selected, -1=none (default: -1)\n"
@@ -259,7 +259,7 @@ static void parse_csv_strings(const char *csv, char names[][16], int max_count)
 static void populate_random_counters(void)
 {
     int p, t;
-    for (p = 0; p < MAX_PLAYERS; p++)
+    for (p = 0; p < MAX_DISPLAY_PLAYERS; p++)
         for (t = 0; t < COUNTER_TYPE_COUNT; t++)
             player_counters[p][t] = rand() % 100;
 }
@@ -287,9 +287,9 @@ int main(int argc, char *argv[])
     const char *screen_name = "main";
     const char *outdir = "screenshots";
     const char *output_filename = NULL;
-    int life_values[MAX_PLAYERS] = {0};
+    int life_values[MAX_DISPLAY_PLAYERS] = {0};
     int life_set = 0;
-    char name_values[MAX_PLAYERS][16] = {{0}};
+    char name_values[MAX_GAME_PLAYERS][16] = {{0}};
     int names_set = 0;
     int selected_val = -1;
     int selected_set = 0;
@@ -309,9 +309,9 @@ int main(int argc, char *argv[])
     int all_damage_set = 0;
     int menu_player_val = 0;
     int menu_player_set = 0;
-    int player_color_values[MAX_PLAYERS] = {0, 1, 2, 3};
+    int player_color_values[MAX_DISPLAY_PLAYERS] = {0, 1, 2, 3};
     int player_colors_set = 0;
-    int player_override_values[MAX_PLAYERS] = {0, 0, 0, 0};
+    int player_override_values[MAX_DISPLAY_PLAYERS] = {0, 0, 0, 0};
     int player_override_set = 0;
     int brightness_val = 0;
     int brightness_set = 0;
@@ -329,10 +329,10 @@ int main(int argc, char *argv[])
         if (strcmp(argv[i], "--screen") == 0 && i + 1 < argc) {
             screen_name = argv[++i];
         } else if (strcmp(argv[i], "--life") == 0 && i + 1 < argc) {
-            parse_csv_ints(argv[++i], life_values, MAX_PLAYERS);
+            parse_csv_ints(argv[++i], life_values, MAX_DISPLAY_PLAYERS);
             life_set = 1;
         } else if (strcmp(argv[i], "--names") == 0 && i + 1 < argc) {
-            parse_csv_strings(argv[++i], name_values, MAX_PLAYERS);
+            parse_csv_strings(argv[++i], name_values, MAX_GAME_PLAYERS);
             names_set = 1;
         } else if (strcmp(argv[i], "--players") == 0 && i + 1 < argc) {
             sim_nvs_preset_i8("num_players", (int8_t)atoi(argv[++i]));
@@ -382,10 +382,10 @@ int main(int argc, char *argv[])
             menu_player_val = atoi(argv[++i]);
             menu_player_set = 1;
         } else if (strcmp(argv[i], "--player-colors") == 0 && i + 1 < argc) {
-            parse_csv_ints(argv[++i], player_color_values, MAX_PLAYERS);
+            parse_csv_ints(argv[++i], player_color_values, MAX_DISPLAY_PLAYERS);
             player_colors_set = 1;
         } else if (strcmp(argv[i], "--player-override") == 0 && i + 1 < argc) {
-            parse_csv_ints(argv[++i], player_override_values, MAX_PLAYERS);
+            parse_csv_ints(argv[++i], player_override_values, MAX_DISPLAY_PLAYERS);
             player_override_set = 1;
         } else if (strcmp(argv[i], "--battery-voltage") == 0 && i + 1 < argc) {
             sim_battery_voltage = (float)atof(argv[++i]);
@@ -429,11 +429,11 @@ int main(int argc, char *argv[])
     /* Apply RAM-only overrides after navigation */
     #define APPLY_RAM_OVERRIDES() do { \
         if (life_set) { \
-            for (i = 0; i < MAX_PLAYERS; i++) \
+            for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) \
                 player_life[i] = life_values[i]; \
         } \
         if (names_set) { \
-            for (i = 0; i < MAX_PLAYERS; i++) { \
+            for (i = 0; i < MAX_GAME_PLAYERS; i++) { \
                 if (name_values[i][0]) \
                     snprintf(player_names[i], sizeof(player_names[i]), "%s", name_values[i]); \
             } \
@@ -474,11 +474,11 @@ int main(int argc, char *argv[])
             menu_player = menu_player_val; \
         } \
         if (player_colors_set) { \
-            for (i = 0; i < MAX_PLAYERS; i++) \
+            for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) \
                 player_color_index[i] = player_color_values[i]; \
         } \
         if (player_override_set) { \
-            for (i = 0; i < MAX_PLAYERS; i++) \
+            for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) \
                 player_has_override[i] = (bool)player_override_values[i]; \
         } \
         if (do_random_counters) \
@@ -497,6 +497,8 @@ int main(int argc, char *argv[])
             else \
                 turn_elapsed_ms = 0; \
         } \
+        for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) \
+            check_player_elimination(i); \
         refresh_main_ui(); \
         lv_obj_update_layout(lv_scr_act()); \
         refresh_multiplayer_ui(); \


### PR DESCRIPTION
## Summary
- Extends the game from 4 to 8 total players for commander damage tracking (closes #65)
- Only 4 life totals are displayed on screen — off-screen players (5-8) exist solely as commander damage sources with a name and positional color
- Introduces `MAX_GAME_PLAYERS` (8) and renames `MAX_PLAYERS` to `MAX_DISPLAY_PLAYERS` (4) for clarity
- `cmd_damage_totals` is now `[8][4]` (any of 8 sources → 4 tracked targets)
- Enemy select screen uses a unified 2-column grid layout for all enemy counts (1-7), inspired by the mana tracker
- `get_player_text_color` generalized with `color_is_light()` so it works for all 8 player colors
- Game mode menu cycles players 1-8; track stays capped at 4

## Screenshots
<img width="2360" height="3664" alt="IMG_0024" src="https://github.com/user-attachments/assets/78241369-3332-4cfa-af7b-c677c530efc8" />

## Test plan
- [x] Compile firmware with `make firmware`
- [x] Set players to 8, track to 4 in game mode menu and apply
- [x] Open commander damage for a tracked player — verify all 7 enemies shown in grid
- [x] Tap an enemy box, adjust damage with knob, apply — verify life decreases and damage total persists
- [x] Verify off-screen player (P5-P8) damage triggers elimination at 21+
- [x] Verify eliminated player shows grayed out in the grid and is not tappable
- [x] Test with 2, 4, 6, 8 players — verify grid adapts correctly
- [x] Undo commander damage from damage log — verify it reverses correctly
- [x] Review full screenshot matrix (`make generate-matrix`) for visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)