### PR TITLE
Fix reversed knob direction on K718 board

### DIFF
--- a/knobby/board_detect.c
+++ b/knobby/board_detect.c
@@ -34,7 +34,7 @@ const board_pins_t board_k718 = {
     .tft_blk    = 21,  .tft_rst  = 17,  .tft_cs  = 12,  .tft_sck = 11,
     .tft_sda0   = 13,  .tft_sda1 = 14,  .tft_sda2 = 15, .tft_sda3 = 16,
     .touch_scl  = 10,  .touch_sda = 9,  .touch_int = 7,  .touch_rst = 8,
-    .enc_a      = 2,   .enc_b    = 1,
+    .enc_a      = 1,   .enc_b    = 2,
     .bat_adc    = 6,
     .btn        = 0,
     .mirror_x   = true,  .mirror_y = true,


### PR DESCRIPTION
## Summary
- Swap encoder A/B pins in K718 board config to correct reversed knob direction
- The K718 mirrors both display axes, which reverses the perceived rotation — swapping the pins compensates

## Test plan
- [x] Verify knob turns right = life increase on K718 device
- [x] Verify K518 knob direction is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)