### PR TITLE
Fix swipe-down accidentally toggling menu buttons

### DIFF
--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -57,6 +57,7 @@ void build_quad_screen(lv_obj_t **screen, quad_item_t items[4])
     for (i = 0; i < 4; i++) {
         lv_obj_t *btn = lv_btn_create(*screen);
         lv_obj_remove_style_all(btn);
+        lv_obj_clear_flag(btn, LV_OBJ_FLAG_PRESS_LOCK);
         lv_obj_set_size(btn, 178, 178);
         lv_obj_set_style_radius(btn, 0, 0);
         lv_obj_set_pos(btn, qx[i], qy[i]);


### PR DESCRIPTION
## Summary
- Clear `LV_OBJ_FLAG_PRESS_LOCK` on all quad menu buttons in `build_quad_screen()`
- When swiping down to close a menu, the finger sliding off a toggle button now sends `PRESS_LOST` instead of `CLICKED`, preventing accidental setting changes
- Affects all quad menus (main, tools, screen settings, settings page 2, player menu, counter menu, color menu)

## Test plan
- [x] Swipe down on screen settings menu (auto-dim, brightness, battery, more) — no toggles should fire
- [x] Swipe down on settings page 2 (color mode, deselect, orientation, auto-eliminate) — no toggles should fire
- [x] Tap toggle buttons normally — should still cycle/toggle as expected
- [x] Verify on all quad menus that normal taps still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)