### PR TITLE
Render circular screen in simulator to match hardware

### DIFF
--- a/sim/sim_sdl2.c
+++ b/sim/sim_sdl2.c
@@ -46,17 +46,30 @@ static void update_sdl_display(void)
 {
     void *pixels;
     int pitch;
+    const int cx = SCREEN_W / 2;
+    const int cy = SCREEN_H / 2;
+    const int rr = (SCREEN_W / 2) * (SCREEN_W / 2);
+    const uint32_t bezel = 0xFF505050;
     SDL_LockTexture(texture, NULL, &pixels, &pitch);
-    
+
     uint32_t *p = (uint32_t *)pixels;
-    for (int i = 0; i < SCREEN_W * SCREEN_H; i++) {
-        lv_color_t c = framebuffer[i];
-        uint8_t r = (uint8_t)((c.ch.red * 255) / 31);
-        uint8_t g = (uint8_t)((c.ch.green * 255) / 63);
-        uint8_t b = (uint8_t)((c.ch.blue * 255) / 31);
-        p[i] = (0xFF << 24) | (r << 16) | (g << 8) | b;
+    for (int y = 0; y < SCREEN_H; y++) {
+        for (int x = 0; x < SCREEN_W; x++) {
+            int i = y * SCREEN_W + x;
+            int dx = x - cx;
+            int dy = y - cy;
+            if (dx * dx + dy * dy > rr) {
+                p[i] = bezel;
+            } else {
+                lv_color_t c = framebuffer[i];
+                uint8_t r = (uint8_t)((c.ch.red * 255) / 31);
+                uint8_t g = (uint8_t)((c.ch.green * 255) / 63);
+                uint8_t b = (uint8_t)((c.ch.blue * 255) / 31);
+                p[i] = (0xFF << 24) | (r << 16) | (g << 8) | b;
+            }
+        }
     }
-    
+
     SDL_UnlockTexture(texture);
     SDL_RenderClear(renderer);
     SDL_RenderCopy(renderer, texture, NULL, NULL);


### PR DESCRIPTION
## Summary
- Live SDL2 simulator now masks pixels outside the 180-radius circle with a dark grey (#505050) bezel, matching the circular display on hardware.
- Mirrors the mask already applied by `save_screenshot_png` in `sim_main.c` (the headless screenshot path), so live sim and screenshots now agree on the visible area.

## Test plan
- [x] `sim.sh` launches and the four corners outside the circle show the grey bezel
- [x] UI elements near the edges (arc on 1p, quadrant edges on 4p) are clipped visually exactly like the hardware
- [x] Screenshot generation (`make screenshot`) still works and outputs the existing #E0E0E0 light-grey bezel unchanged