### PR TITLE
Add low-battery indicator on player screens

### DIFF
--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -76,6 +76,7 @@ static void handle_back_navigation(lv_obj_t *screen)
     } else if (screen == screen_settings_page2) {
         lv_scr_load(screen_screen_settings_menu);
     } else if (screen == screen_settings) {
+        settings_save();
         lv_scr_load(screen_screen_settings_menu);
     } else if (screen == screen_battery) {
         lv_scr_load(screen_screen_settings_menu);

--- a/knobby/src/hw.c
+++ b/knobby/src/hw.c
@@ -30,6 +30,12 @@ static uint32_t last_activity_tick = 0;
 static uint32_t undim_tick = 0;
 static lv_timer_t *auto_dim_timer = NULL;
 
+#define BATTERY_ICON_MAX 8
+static lv_obj_t *battery_icons[BATTERY_ICON_MAX];
+static int battery_icon_count = 0;
+static bool battery_icon_blink_visible = true;
+static lv_timer_t *battery_icon_timer = NULL;
+
 // ---------- battery curve ----------
 static const float battery_curve_voltages[] = {
     3.35f, 3.55f, 3.68f, 3.74f, 3.80f, 3.88f, 3.96f, 4.06f, 4.18f
@@ -109,6 +115,53 @@ int read_battery_percent(void)
     update_battery_measurement(false);
     if (!battery_sample_valid) return -1;
     return battery_percent_from_voltage(battery_voltage);
+}
+
+// ---------- low-battery indicator ----------
+void battery_icon_register(lv_obj_t *icon)
+{
+    if (icon == NULL || battery_icon_count >= BATTERY_ICON_MAX) return;
+    battery_icons[battery_icon_count++] = icon;
+    lv_obj_add_flag(icon, LV_OBJ_FLAG_HIDDEN);
+}
+
+void battery_icon_unregister(lv_obj_t *icon)
+{
+    int i;
+    if (icon == NULL) return;
+    for (i = 0; i < battery_icon_count; i++) {
+        if (battery_icons[i] == icon) {
+            battery_icons[i] = battery_icons[--battery_icon_count];
+            return;
+        }
+    }
+}
+
+static void battery_icon_apply(bool visible)
+{
+    int i;
+    for (i = 0; i < battery_icon_count; i++) {
+        if (visible) lv_obj_clear_flag(battery_icons[i], LV_OBJ_FLAG_HIDDEN);
+        else         lv_obj_add_flag(battery_icons[i], LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+static void battery_icon_timer_cb(lv_timer_t *timer)
+{
+    (void)timer;
+    int pct = read_battery_percent();
+    if (pct < 0 || pct >= LOW_BATTERY_INDICATOR_PCT) {
+        battery_icon_blink_visible = true;
+        battery_icon_apply(false);
+        return;
+    }
+    if (pct >= LOW_BATTERY_BLINK_PCT) {
+        battery_icon_blink_visible = true;
+        battery_icon_apply(true);
+        return;
+    }
+    battery_icon_apply(battery_icon_blink_visible);
+    battery_icon_blink_visible = !battery_icon_blink_visible;
 }
 
 // ---------- brightness ----------
@@ -200,4 +253,5 @@ void knob_hw_init(void)
     auto_dim_setting = nvs_get_auto_dim();
     last_activity_tick = lv_tick_get();
     auto_dim_timer = lv_timer_create(auto_dim_timer_cb, AUTO_DIM_CHECK_PERIOD_MS, NULL);
+    battery_icon_timer = lv_timer_create(battery_icon_timer_cb, BATTERY_BLINK_PERIOD_MS, NULL);
 }

--- a/knobby/src/hw.h
+++ b/knobby/src/hw.h
@@ -28,6 +28,9 @@ extern int battery_percent;
 #define LOW_BATTERY_VOLTAGE         3.35f   /* shutdown threshold (matches 0% curve) */
 #define LOW_BATTERY_COUNT           3       /* consecutive low readings before cutoff */
 #define LOW_BATTERY_WAKE_US         (15ULL * 1000000ULL)  /* deep sleep wake interval */
+#define LOW_BATTERY_INDICATOR_PCT   10      /* show solid icon below this percent */
+#define LOW_BATTERY_BLINK_PCT       5       /* blink the icon below this percent */
+#define BATTERY_BLINK_PERIOD_MS     500     /* low-battery icon blink cadence */
 
 // ---------- functions ----------
 void knob_hw_init(void);
@@ -37,6 +40,8 @@ int read_battery_percent(void);
 void change_brightness(int delta);
 bool in_undim_grace(void);
 void knob_enter_deep_sleep(void);
+void battery_icon_register(lv_obj_t *icon);
+void battery_icon_unregister(lv_obj_t *icon);
 
 #ifdef __cplusplus
 }

--- a/knobby/src/ui_1p.c
+++ b/knobby/src/ui_1p.c
@@ -5,6 +5,7 @@
 #include "game.h"
 #include "timer.h"
 #include "storage.h"
+#include "hw.h"
 
 // ---------- screens ----------
 lv_obj_t *screen_1p = NULL;
@@ -468,6 +469,14 @@ void build_main_screen(void)
         &counter_row_1p[COUNTER_TYPE_EXPERIENCE],
         &counter_value_1p[COUNTER_TYPE_EXPERIENCE]);
 
+    {
+        lv_obj_t *batt = lv_label_create(screen_1p);
+        lv_label_set_text(batt, LV_SYMBOL_BATTERY_EMPTY);
+        lv_obj_set_style_text_color(batt, lv_palette_main(LV_PALETTE_RED), 0);
+        lv_obj_set_style_text_font(batt, &lv_font_montserrat_22, 0);
+        lv_obj_align(batt, LV_ALIGN_TOP_MID, 0, 28);
+        battery_icon_register(batt);
+    }
 }
 
 void build_select_screen(void)

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -3,6 +3,20 @@
 #include "ui_1p.h"
 #include "game.h"
 #include "storage.h"
+#include "hw.h"
+
+static lv_obj_t *add_low_battery_icon(lv_obj_t *parent)
+{
+    lv_obj_t *batt = lv_label_create(parent);
+    lv_label_set_text(batt, LV_SYMBOL_BATTERY_EMPTY);
+    lv_obj_set_style_text_color(batt, lv_palette_main(LV_PALETTE_RED), 0);
+    lv_obj_set_style_text_font(batt, &lv_font_montserrat_22, 0);
+    lv_obj_align(batt, LV_ALIGN_TOP_MID, 0, 28);
+    battery_icon_register(batt);
+    return batt;
+}
+
+static lv_obj_t *mp_battery_icon = NULL;
 
 #include <string.h>
 
@@ -495,6 +509,11 @@ void rebuild_multiplayer_layout(int track)
 
     if (screen_multiplayer == NULL) return;
 
+    if (mp_battery_icon != NULL) {
+        battery_icon_unregister(mp_battery_icon);
+        mp_battery_icon = NULL;
+    }
+
     lv_obj_clean(screen_multiplayer);
     memset(&mp_state, 0, sizeof(mp_state));
     mp_state.layout = layout;
@@ -547,6 +566,8 @@ void rebuild_multiplayer_layout(int track)
             &mp_state.counter_rows[i][COUNTER_TYPE_EXPERIENCE],
             &mp_state.counter_values[i][COUNTER_TYPE_EXPERIENCE], p);
     }
+
+    mp_battery_icon = add_low_battery_icon(screen_multiplayer);
 
     refresh_multiplayer_ui();
 }

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -269,6 +269,19 @@ v=${voltages[$((RANDOM % ${#voltages[@]}))]}
 shot "battery_${v}v.png" --screen battery --battery-voltage "$v"
 
 # ============================================================
+# 16b. Low-battery indicator on gameplay screens
+# ============================================================
+# 3.62V is ~8% (solid icon, 5-10% tier).  3.40V is ~3% (blink, <5% tier).
+# Note: blink screenshot captures the visible phase deterministically
+# because the icon shows on the first timer fire after entering low state.
+shot "lowbatt_solid_1p.png" --screen 1p --track 1 --battery-voltage 3.62
+shot "lowbatt_blink_1p.png" --screen 1p --track 1 --battery-voltage 3.40
+for track in 2 3 4; do
+    shot "lowbatt_solid_${track}p.png" --screen ${track}p --track "$track" \
+        --orientation 0 --battery-voltage 3.62
+done
+
+# ============================================================
 # 17. Dice with a result
 # ============================================================
 shot "dice_$((RANDOM % 20 + 1)).png" --screen dice --dice $((RANDOM % 20 + 1))
@@ -361,10 +374,12 @@ SEC_LIFE=(); SEC_LIFECOLOR=(); SEC_PERPLAYER=(); SEC_SELECTED=(); SEC_COUNTERS=(
 SEC_BRIGHT=(); SEC_COUNTER_EDIT=(); SEC_DAMAGE=(); SEC_SETTINGS=()
 SEC_TIMER=()
 SEC_MANA=()
+SEC_LOWBATT=()
 SEC_OTHER=()
 
 for f in "${FILES[@]}"; do
     case "$f" in
+        lowbatt_*)            SEC_LOWBATT+=("$f") ;;
         1p_preview_*)         SEC_1P_PREV+=("$f") ;;
         2p_*_preview_*)       SEC_2P_PREV+=("$f") ;;
         3p_*_preview_*)       SEC_3P_PREV+=("$f") ;;
@@ -399,6 +414,7 @@ write_section "Counter Edit" "${SEC_COUNTER_EDIT[@]}"
 write_section "Damage / Select" "${SEC_DAMAGE[@]}"
 write_section "Settings" "${SEC_SETTINGS[@]}"
 write_section "Mana Pool" "${SEC_MANA[@]}"
+write_section "Low Battery Indicator" "${SEC_LOWBATT[@]}"
 write_section "Other" "${SEC_OTHER[@]}"
 
 echo '</body></html>' >> "$INDEX"

--- a/sim/sim_sdl2.c
+++ b/sim/sim_sdl2.c
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -103,6 +105,14 @@ static void main_loop(void)
 
 int main(int argc, char *argv[])
 {
+    extern float sim_battery_voltage;
+    int i;
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--battery-voltage") == 0 && i + 1 < argc) {
+            sim_battery_voltage = (float)atof(argv[++i]);
+        }
+    }
+
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         fprintf(stderr, "SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
         return 1;


### PR DESCRIPTION
## Summary
- Red battery icon at top-center of the 1p and multiplayer screens. Hidden when battery is healthy, solid below 10%, blinks at 500ms below 5%.
- Adds `--battery-voltage` to the GUI sim for interactive verification (matches the screenshot sim's existing flag).
- Bundled fix: brightness changes now persist after backing out of the brightness arc page. Previously `settings_save()` only ran when leaving the parent settings menu, so a brightness change followed by a power-cycle would revert to the default.

## Test plan
- [ ] On hardware: confirm icon hidden at full battery, appears solid as voltage drops past 10%, blinks below 5%
- [x] In GUI sim: `sim/knobby_sim_gui --battery-voltage 3.40` (blink tier, ~3%) and `3.62` (solid tier, ~8%) — icon visible
- [x] In GUI sim: default `--battery-voltage 4.0` — icon hidden
- [x] Switch player count via Game Mode menu — icon persists across mp layout rebuilds (1p→2p→3p→4p)
- [x] Brightness fix: change brightness, back out once to settings menu, power-cycle device, confirm value persists

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
