### PR TITLE
Suppress click leak after long-press screen transitions (closes #91)

### DIFF
--- a/knobby/src/game_mode.c
+++ b/knobby/src/game_mode.c
@@ -112,6 +112,7 @@ static void event_gm_life_custom(lv_event_t *e)
     (void)e;
     refresh_custom_life_ui();
     lv_scr_load(screen_custom_life);
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 static void event_gm_apply(lv_event_t *e)
@@ -124,6 +125,7 @@ static void event_gm_apply(lv_event_t *e)
     reset_all_values();
     rebuild_multiplayer_layout(temp_players_to_track);
     back_to_main();
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 // ---------- screen builders ----------

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -350,6 +350,7 @@ static void event_general_reset(lv_event_t *e)
     damage_log_reset();
     reset_all_values();
     back_to_main();
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 // ---------- screen builders ----------

--- a/knobby/src/ui_1p.c
+++ b/knobby/src/ui_1p.c
@@ -317,6 +317,7 @@ static void event_open_1p_menu(lv_event_t *e)
 {
     (void)e;
     open_player_menu(0);
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 static void event_select_enemy(lv_event_t *e)

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -461,6 +461,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
     if (player_eliminated[player]) {
         menu_player = player;
         load_screen_if_needed(screen_eliminated_player_menu);
+        lv_indev_wait_release(lv_indev_get_act());
         return;
     }
 
@@ -471,6 +472,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
     selected_player = player;
     refresh_multiplayer_ui();
     open_player_menu(selected_player);
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 /* ---------- selection timeout ---------- */

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -109,6 +109,7 @@ static void event_menu_rename_all(lv_event_t *e)
 {
     (void)e;
     open_rename_all_screen();
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 static void event_menu_cmd_damage(lv_event_t *e)
@@ -146,6 +147,7 @@ static void event_menu_eliminate(lv_event_t *e)
     (void)e;
     manual_eliminate_player(menu_player);
     back_to_main();
+    lv_indev_wait_release(lv_indev_get_act());
 }
 
 static void event_counter_commander_tax(lv_event_t *e)


### PR DESCRIPTION
## Summary
- Fixes #91: long-press on a multiplayer panel was instantly skipping past the player menu into a sub-menu (commander damage, etc.).
- Root cause: with the panel's `LV_OBJ_FLAG_PRESS_LOCK` cleared, LVGL re-targeted the in-flight press onto whichever quad button sat under the finger after the screen swap, then fired `CLICKED` on release.
- Fix: call `lv_indev_wait_release()` after each long-press handler that loads a new screen, so LVGL ignores the indev until the user actually lifts their finger. `lv_indev_reset()` alone wasn't enough because the touch driver keeps reporting `PRESSED` on every read.
- Applied to all eight long-press → screen-transition sites across `ui_mp.c`, `ui_1p.c`, `ui_player_menu.c`, `game_mode.c`, `settings.c`.

## Test plan
- [x] Firmware compiles (838,927 bytes, 64% of partition)
- [x] Simulator compiles
- [x] MP panel long-press → player menu — lift over each quad button (Name/Color, Commander Damage, All Damage, Counters); should land on the player menu without entering a sub-menu
- [x] MP panel long-press on an eliminated player → eliminated-player menu (Undo)
- [x] 1p life screen long-press → player menu
- [x] Player menu: long-press Counters (= eliminate); long-press Rename (= rename-all)
- [x] Game Mode menu: long-press Apply; long-press Life total (= custom life)
- [x] Settings: long-press Reset
- [x] Tap-to-select on MP panels still toggles correctly (no regression)
- [x] Short-tap navigation in player menu / game mode / settings still works
- [x] Swipe gestures still work (unrelated path, but uses the same indev primitives)
