### PR TITLE
Copilot/add swipe navigation visual hint

### DIFF
--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -162,6 +162,33 @@ static int get_swipe_hint_distance(knob_swipe_direction_t direction, int dx, int
     }
 }
 
+static int get_swipe_hint_progress(knob_swipe_direction_t direction, int dx, int dy)
+{
+    int distance = get_swipe_hint_distance(direction, dx, dy);
+
+    return clamp_value(scale_value(distance - KNOB_SWIPE_HINT_REVEAL_START,
+                                   KNOB_SWIPE_THRESHOLD - KNOB_SWIPE_HINT_REVEAL_START,
+                                   SWIPE_HINT_OPACITY_MAX),
+                       SWIPE_HINT_OPACITY_MIN,
+                       SWIPE_HINT_OPACITY_MAX);
+}
+
+bool knob_swipe_hint_fully_revealed(lv_obj_t *screen,
+                                    int start_x, int start_y,
+                                    int cur_x, int cur_y)
+{
+    knob_swipe_direction_t direction;
+    int dx = cur_x - start_x;
+    int dy = cur_y - start_y;
+
+    direction = knob_classify_swipe_direction(screen, start_x, start_y,
+                                              dx, dy,
+                                              KNOB_SWIPE_HINT_REVEAL_START);
+    if (direction == KNOB_SWIPE_NONE) return false;
+
+    return get_swipe_hint_progress(direction, dx, dy) >= SWIPE_HINT_OPACITY_MAX;
+}
+
 static void ensure_swipe_hint(void)
 {
     if (swipe_hint != NULL) return;
@@ -223,10 +250,7 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
 
     width = get_display_width();
     height = get_display_height();
-        progress = scale_value(distance - KNOB_SWIPE_HINT_REVEAL_START,
-                   KNOB_SWIPE_THRESHOLD - KNOB_SWIPE_HINT_REVEAL_START,
-                           SWIPE_HINT_OPACITY_MAX);
-    progress = clamp_value(progress, SWIPE_HINT_OPACITY_MIN, SWIPE_HINT_OPACITY_MAX);
+    progress = get_swipe_hint_progress(direction, dx, dy);
     inset = SWIPE_HINT_EDGE_INSET +
             scale_value(distance - KNOB_SWIPE_HINT_REVEAL_START,
                         KNOB_SWIPE_THRESHOLD,

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -82,6 +82,12 @@ static int clamp_value(int value, int min_value, int max_value)
     return value;
 }
 
+static int scale_value(int value, int input_max, int output_max)
+{
+    if (value <= 0 || input_max <= 0 || output_max <= 0) return 0;
+    return (int)(((int64_t)value * output_max) + (input_max / 2)) / input_max;
+}
+
 static int get_display_width(void)
 {
     lv_disp_t *disp = lv_disp_get_default();
@@ -221,10 +227,15 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
 
     width = get_display_width();
     height = get_display_height();
-    progress = ((distance - SWIPE_HINT_REVEAL_START) * SWIPE_HINT_OPACITY_MAX) / (KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START);
+    progress = scale_value(distance - SWIPE_HINT_REVEAL_START,
+                           KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START,
+                           SWIPE_HINT_OPACITY_MAX);
     if (progress < SWIPE_HINT_OPACITY_MIN) progress = SWIPE_HINT_OPACITY_MIN;
     if (progress > SWIPE_HINT_OPACITY_MAX) progress = SWIPE_HINT_OPACITY_MAX;
-    inset = SWIPE_HINT_EDGE_INSET + ((distance - SWIPE_HINT_REVEAL_START) * SWIPE_HINT_TRAVEL) / KNOB_SWIPE_THRESHOLD;
+    inset = SWIPE_HINT_EDGE_INSET +
+            scale_value(distance - SWIPE_HINT_REVEAL_START,
+                        KNOB_SWIPE_THRESHOLD,
+                        SWIPE_HINT_TRAVEL);
     if (inset > (SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL)) {
         inset = SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL;
     }
@@ -256,7 +267,9 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
 
     lv_label_set_text(swipe_hint_icon, symbol);
     lv_obj_set_pos(swipe_hint, pos_x, pos_y);
-    lv_obj_set_style_bg_opa(swipe_hint, (lv_opa_t)((progress * SWIPE_HINT_BG_OPACITY_MAX) / SWIPE_HINT_OPACITY_MAX), 0);
+    lv_obj_set_style_bg_opa(swipe_hint,
+                            (lv_opa_t)scale_value(progress, SWIPE_HINT_OPACITY_MAX, SWIPE_HINT_BG_OPACITY_MAX),
+                            0);
     lv_obj_set_style_text_opa(swipe_hint_icon, (lv_opa_t)progress, 0);
     lv_obj_clear_flag(swipe_hint, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_foreground(swipe_hint);

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -84,7 +84,7 @@ static int clamp_value(int value, int min_value, int max_value)
 
 static int scale_value(int value, int input_max, int output_max)
 {
-    if (value <= 0 || input_max <= 0 || output_max <= 0) return 0;
+    if (value < 0 || input_max <= 0 || output_max <= 0) return 0;
     return (int)(((int64_t)value * output_max) + (input_max / 2)) / input_max;
 }
 
@@ -230,8 +230,7 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
     progress = scale_value(distance - SWIPE_HINT_REVEAL_START,
                            KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START,
                            SWIPE_HINT_OPACITY_MAX);
-    if (progress < SWIPE_HINT_OPACITY_MIN) progress = SWIPE_HINT_OPACITY_MIN;
-    if (progress > SWIPE_HINT_OPACITY_MAX) progress = SWIPE_HINT_OPACITY_MAX;
+    progress = clamp_value(progress, SWIPE_HINT_OPACITY_MIN, SWIPE_HINT_OPACITY_MAX);
     inset = SWIPE_HINT_EDGE_INSET +
             scale_value(distance - SWIPE_HINT_REVEAL_START,
                         KNOB_SWIPE_THRESHOLD,

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -16,10 +16,27 @@
 
 // ---------- swipe state ----------
 static lv_obj_t *previous_screen = NULL;
+static lv_obj_t *swipe_hint = NULL;
+static lv_obj_t *swipe_hint_icon = NULL;
 static volatile bool swipe_up_pending = false;
 static volatile bool swipe_down_pending = false;
 static volatile bool swipe_left_pending = false;
 static volatile bool swipe_right_pending = false;
+
+#define SWIPE_HINT_SIZE 52
+#define SWIPE_HINT_EDGE_INSET 12
+#define SWIPE_HINT_TRAVEL 18
+#define SWIPE_HINT_REVEAL_START 12
+#define SWIPE_HINT_TOP_EDGE_ZONE 80
+#define SWIPE_HINT_BOTTOM_EDGE_ZONE 80
+
+typedef enum {
+    SWIPE_HINT_NONE = 0,
+    SWIPE_HINT_LEFT,
+    SWIPE_HINT_RIGHT,
+    SWIPE_HINT_UP,
+    SWIPE_HINT_DOWN
+} swipe_hint_direction_t;
 
 // ---------- knob event queue ----------
 static int last_knob_cont = 0;
@@ -53,6 +70,193 @@ static bool is_player_screen(lv_obj_t *screen)
 {
     return screen == screen_1p ||
            screen == screen_multiplayer;
+}
+
+static int clamp_coord(int value, int min_value, int max_value)
+{
+    if (value < min_value) return min_value;
+    if (value > max_value) return max_value;
+    return value;
+}
+
+static int get_display_width(void)
+{
+    lv_disp_t *disp = lv_disp_get_default();
+    return (disp != NULL) ? (int)lv_disp_get_hor_res(disp) : 360;
+}
+
+static int get_display_height(void)
+{
+    lv_disp_t *disp = lv_disp_get_default();
+    return (disp != NULL) ? (int)lv_disp_get_ver_res(disp) : 360;
+}
+
+static swipe_hint_direction_t get_swipe_hint_direction(lv_obj_t *screen,
+                                                       int start_x, int start_y,
+                                                       int dx, int dy)
+{
+    int width = get_display_width();
+    int height = get_display_height();
+    int abs_dx = dx >= 0 ? dx : -dx;
+    int abs_dy = dy >= 0 ? dy : -dy;
+
+    if (is_player_screen(screen)) {
+        if (start_x <= KNOB_SWIPE_LEFT_EDGE_ZONE &&
+            dx > SWIPE_HINT_REVEAL_START &&
+            abs_dy < KNOB_SWIPE_MAX_LATERAL &&
+            dx >= abs_dy) {
+            return SWIPE_HINT_RIGHT;
+        }
+        if (start_x >= (width - KNOB_SWIPE_RIGHT_EDGE_ZONE) &&
+            -dx > SWIPE_HINT_REVEAL_START &&
+            abs_dy < KNOB_SWIPE_MAX_LATERAL &&
+            -dx >= abs_dy) {
+            return SWIPE_HINT_LEFT;
+        }
+        if (start_y <= SWIPE_HINT_TOP_EDGE_ZONE &&
+            dy > SWIPE_HINT_REVEAL_START &&
+            abs_dx < KNOB_SWIPE_MAX_LATERAL &&
+            dy >= abs_dx) {
+            return SWIPE_HINT_DOWN;
+        }
+        if (start_y >= (height - SWIPE_HINT_BOTTOM_EDGE_ZONE) &&
+            -dy > SWIPE_HINT_REVEAL_START &&
+            abs_dx < KNOB_SWIPE_MAX_LATERAL &&
+            -dy >= abs_dx) {
+            return SWIPE_HINT_UP;
+        }
+    } else {
+        if (start_x >= (width - KNOB_SWIPE_RIGHT_EDGE_ZONE) &&
+            -dx > SWIPE_HINT_REVEAL_START &&
+            abs_dy < KNOB_SWIPE_MAX_LATERAL &&
+            -dx >= abs_dy) {
+            return SWIPE_HINT_LEFT;
+        }
+        if (dy > SWIPE_HINT_REVEAL_START &&
+            abs_dx < KNOB_SWIPE_MAX_LATERAL &&
+            dy >= abs_dx) {
+            return SWIPE_HINT_DOWN;
+        }
+    }
+
+    return SWIPE_HINT_NONE;
+}
+
+static int get_swipe_hint_distance(swipe_hint_direction_t direction, int dx, int dy)
+{
+    switch (direction) {
+    case SWIPE_HINT_LEFT:
+        return -dx;
+    case SWIPE_HINT_RIGHT:
+        return dx;
+    case SWIPE_HINT_UP:
+        return -dy;
+    case SWIPE_HINT_DOWN:
+        return dy;
+    default:
+        return 0;
+    }
+}
+
+static void ensure_swipe_hint(void)
+{
+    if (swipe_hint != NULL) return;
+
+    swipe_hint = lv_obj_create(lv_layer_top());
+    lv_obj_remove_style_all(swipe_hint);
+    lv_obj_set_size(swipe_hint, SWIPE_HINT_SIZE, SWIPE_HINT_SIZE);
+    lv_obj_set_style_radius(swipe_hint, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_color(swipe_hint, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(swipe_hint, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(swipe_hint, 0, 0);
+    lv_obj_set_style_outline_width(swipe_hint, 0, 0);
+    lv_obj_set_style_pad_all(swipe_hint, 0, 0);
+    lv_obj_clear_flag(swipe_hint, LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(swipe_hint, LV_OBJ_FLAG_HIDDEN);
+
+    swipe_hint_icon = lv_label_create(swipe_hint);
+    lv_label_set_text(swipe_hint_icon, LV_SYMBOL_LEFT);
+    lv_obj_set_style_text_font(swipe_hint_icon, &lv_font_montserrat_32, 0);
+    lv_obj_set_style_text_color(swipe_hint_icon, lv_color_white(), 0);
+    lv_obj_set_style_text_opa(swipe_hint_icon, LV_OPA_TRANSP, 0);
+    lv_obj_center(swipe_hint_icon);
+}
+
+void knob_swipe_hint_clear(void)
+{
+    if (swipe_hint == NULL) return;
+    lv_obj_add_flag(swipe_hint, LV_OBJ_FLAG_HIDDEN);
+}
+
+void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
+{
+    lv_obj_t *screen = lv_scr_act();
+    swipe_hint_direction_t direction;
+    int dx = cur_x - start_x;
+    int dy = cur_y - start_y;
+    int distance;
+    int width;
+    int height;
+    int progress;
+    int inset;
+    int pos_x;
+    int pos_y;
+    const char *symbol;
+
+    ensure_swipe_hint();
+    direction = get_swipe_hint_direction(screen, start_x, start_y, dx, dy);
+    if (direction == SWIPE_HINT_NONE) {
+        knob_swipe_hint_clear();
+        return;
+    }
+
+    distance = get_swipe_hint_distance(direction, dx, dy);
+    if (distance <= SWIPE_HINT_REVEAL_START) {
+        knob_swipe_hint_clear();
+        return;
+    }
+
+    width = get_display_width();
+    height = get_display_height();
+    progress = ((distance - SWIPE_HINT_REVEAL_START) * 255) / (KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START);
+    if (progress < 48) progress = 48;
+    if (progress > 255) progress = 255;
+    inset = SWIPE_HINT_EDGE_INSET + ((distance - SWIPE_HINT_REVEAL_START) * SWIPE_HINT_TRAVEL) / KNOB_SWIPE_THRESHOLD;
+    if (inset > (SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL)) {
+        inset = SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL;
+    }
+
+    pos_x = clamp_coord(start_x - (SWIPE_HINT_SIZE / 2), SWIPE_HINT_EDGE_INSET, width - SWIPE_HINT_SIZE - SWIPE_HINT_EDGE_INSET);
+    pos_y = clamp_coord(start_y - (SWIPE_HINT_SIZE / 2), SWIPE_HINT_EDGE_INSET, height - SWIPE_HINT_SIZE - SWIPE_HINT_EDGE_INSET);
+    symbol = LV_SYMBOL_LEFT;
+
+    switch (direction) {
+    case SWIPE_HINT_RIGHT:
+        symbol = LV_SYMBOL_RIGHT;
+        pos_x = inset;
+        break;
+    case SWIPE_HINT_LEFT:
+        symbol = LV_SYMBOL_LEFT;
+        pos_x = width - SWIPE_HINT_SIZE - inset;
+        break;
+    case SWIPE_HINT_DOWN:
+        symbol = LV_SYMBOL_DOWN;
+        pos_y = inset;
+        break;
+    case SWIPE_HINT_UP:
+        symbol = LV_SYMBOL_UP;
+        pos_y = height - SWIPE_HINT_SIZE - inset;
+        break;
+    default:
+        break;
+    }
+
+    lv_label_set_text(swipe_hint_icon, symbol);
+    lv_obj_set_pos(swipe_hint, pos_x, pos_y);
+    lv_obj_set_style_bg_opa(swipe_hint, (lv_opa_t)((progress * 120) / 255), 0);
+    lv_obj_set_style_text_opa(swipe_hint_icon, (lv_opa_t)progress, 0);
+    lv_obj_clear_flag(swipe_hint, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(swipe_hint);
 }
 
 static void open_menu_for_screen(lv_obj_t *screen)
@@ -148,6 +352,7 @@ void knob_cb(lv_event_t *e)
 void knob_gui(void)
 {
     knob_hw_init();
+    ensure_swipe_hint();
 
     build_intro_screen();
     lv_scr_load(screen_intro);

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -26,20 +26,9 @@ static volatile bool swipe_right_pending = false;
 #define SWIPE_HINT_SIZE 52
 #define SWIPE_HINT_EDGE_INSET 12
 #define SWIPE_HINT_TRAVEL 18
-#define SWIPE_HINT_REVEAL_START 12
-#define SWIPE_HINT_TOP_EDGE_ZONE 80
-#define SWIPE_HINT_BOTTOM_EDGE_ZONE 80
 #define SWIPE_HINT_OPACITY_MAX 255
 #define SWIPE_HINT_OPACITY_MIN 48
 #define SWIPE_HINT_BG_OPACITY_MAX 120
-
-typedef enum {
-    SWIPE_HINT_NONE = 0,
-    SWIPE_HINT_LEFT,
-    SWIPE_HINT_RIGHT,
-    SWIPE_HINT_UP,
-    SWIPE_HINT_DOWN
-} swipe_hint_direction_t;
 
 // ---------- knob event queue ----------
 static int last_knob_cont = 0;
@@ -100,67 +89,73 @@ static int get_display_height(void)
     return (disp != NULL) ? (int)lv_disp_get_ver_res(disp) : 360;
 }
 
-static swipe_hint_direction_t get_swipe_hint_direction(lv_obj_t *screen,
-                                                       int start_x, int start_y,
-                                                       int dx, int dy)
+static bool is_axis_dominant(int primary, int secondary, int min_travel)
+{
+    if (primary < min_travel) return false;
+    if (secondary > KNOB_SWIPE_MAX_LATERAL) return false;
+    return (primary * KNOB_SWIPE_AXIS_BIAS_DEN) >=
+           (secondary * KNOB_SWIPE_AXIS_BIAS_NUM);
+}
+
+knob_swipe_direction_t knob_classify_swipe_direction(lv_obj_t *screen,
+                                                     int start_x, int start_y,
+                                                     int dx, int dy,
+                                                     int min_travel)
 {
     int width = get_display_width();
     int height = get_display_height();
     int abs_dx = dx >= 0 ? dx : -dx;
     int abs_dy = dy >= 0 ? dy : -dy;
 
+    if (screen == NULL || screen == screen_intro) return KNOB_SWIPE_NONE;
+
     if (is_player_screen(screen)) {
         if (start_x <= KNOB_SWIPE_LEFT_EDGE_ZONE &&
-            dx > SWIPE_HINT_REVEAL_START &&
-            abs_dy < KNOB_SWIPE_MAX_LATERAL &&
-            dx >= abs_dy) {
-            return SWIPE_HINT_RIGHT;
+            dx > 0 &&
+            is_axis_dominant(dx, abs_dy, min_travel)) {
+            return KNOB_SWIPE_RIGHT;
         }
         if (start_x >= (width - KNOB_SWIPE_RIGHT_EDGE_ZONE) &&
-            -dx > SWIPE_HINT_REVEAL_START &&
-            abs_dy < KNOB_SWIPE_MAX_LATERAL &&
-            -dx >= abs_dy) {
-            return SWIPE_HINT_LEFT;
+            dx < 0 &&
+            is_axis_dominant(-dx, abs_dy, min_travel)) {
+            return KNOB_SWIPE_LEFT;
         }
-        if (start_y <= SWIPE_HINT_TOP_EDGE_ZONE &&
-            dy > SWIPE_HINT_REVEAL_START &&
-            abs_dx < KNOB_SWIPE_MAX_LATERAL &&
-            dy >= abs_dx) {
-            return SWIPE_HINT_DOWN;
+        if (start_y <= KNOB_SWIPE_TOP_EDGE_ZONE &&
+            dy > 0 &&
+            is_axis_dominant(dy, abs_dx, min_travel)) {
+            return KNOB_SWIPE_DOWN;
         }
-        if (start_y >= (height - SWIPE_HINT_BOTTOM_EDGE_ZONE) &&
-            -dy > SWIPE_HINT_REVEAL_START &&
-            abs_dx < KNOB_SWIPE_MAX_LATERAL &&
-            -dy >= abs_dx) {
-            return SWIPE_HINT_UP;
+        if (start_y >= (height - KNOB_SWIPE_BOTTOM_EDGE_ZONE) &&
+            dy < 0 &&
+            is_axis_dominant(-dy, abs_dx, min_travel)) {
+            return KNOB_SWIPE_UP;
         }
     } else {
         if (start_x >= (width - KNOB_SWIPE_RIGHT_EDGE_ZONE) &&
-            -dx > SWIPE_HINT_REVEAL_START &&
-            abs_dy < KNOB_SWIPE_MAX_LATERAL &&
-            -dx >= abs_dy) {
-            return SWIPE_HINT_LEFT;
+            dx < 0 &&
+            is_axis_dominant(-dx, abs_dy, min_travel)) {
+            return KNOB_SWIPE_LEFT;
         }
-        if (dy > SWIPE_HINT_REVEAL_START &&
-            abs_dx < KNOB_SWIPE_MAX_LATERAL &&
-            dy >= abs_dx) {
-            return SWIPE_HINT_DOWN;
+        if (start_y <= KNOB_SWIPE_TOP_EDGE_ZONE &&
+            dy > 0 &&
+            is_axis_dominant(dy, abs_dx, min_travel)) {
+            return KNOB_SWIPE_DOWN;
         }
     }
 
-    return SWIPE_HINT_NONE;
+    return KNOB_SWIPE_NONE;
 }
 
-static int get_swipe_hint_distance(swipe_hint_direction_t direction, int dx, int dy)
+static int get_swipe_hint_distance(knob_swipe_direction_t direction, int dx, int dy)
 {
     switch (direction) {
-    case SWIPE_HINT_LEFT:
+    case KNOB_SWIPE_LEFT:
         return -dx;
-    case SWIPE_HINT_RIGHT:
+    case KNOB_SWIPE_RIGHT:
         return dx;
-    case SWIPE_HINT_UP:
+    case KNOB_SWIPE_UP:
         return -dy;
-    case SWIPE_HINT_DOWN:
+    case KNOB_SWIPE_DOWN:
         return dy;
     default:
         return 0;
@@ -200,7 +195,7 @@ void knob_swipe_hint_clear(void)
 void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
 {
     lv_obj_t *screen = lv_scr_act();
-    swipe_hint_direction_t direction;
+    knob_swipe_direction_t direction;
     int dx = cur_x - start_x;
     int dy = cur_y - start_y;
     int distance;
@@ -213,26 +208,27 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
     const char *symbol;
 
     ensure_swipe_hint();
-    direction = get_swipe_hint_direction(screen, start_x, start_y, dx, dy);
-    if (direction == SWIPE_HINT_NONE) {
+    direction = knob_classify_swipe_direction(screen, start_x, start_y, dx, dy,
+                                              KNOB_SWIPE_HINT_REVEAL_START);
+    if (direction == KNOB_SWIPE_NONE) {
         knob_swipe_hint_clear();
         return;
     }
 
     distance = get_swipe_hint_distance(direction, dx, dy);
-    if (distance <= SWIPE_HINT_REVEAL_START) {
+    if (distance <= KNOB_SWIPE_HINT_REVEAL_START) {
         knob_swipe_hint_clear();
         return;
     }
 
     width = get_display_width();
     height = get_display_height();
-    progress = scale_value(distance - SWIPE_HINT_REVEAL_START,
-                           KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START,
+        progress = scale_value(distance - KNOB_SWIPE_HINT_REVEAL_START,
+                   KNOB_SWIPE_THRESHOLD - KNOB_SWIPE_HINT_REVEAL_START,
                            SWIPE_HINT_OPACITY_MAX);
     progress = clamp_value(progress, SWIPE_HINT_OPACITY_MIN, SWIPE_HINT_OPACITY_MAX);
     inset = SWIPE_HINT_EDGE_INSET +
-            scale_value(distance - SWIPE_HINT_REVEAL_START,
+            scale_value(distance - KNOB_SWIPE_HINT_REVEAL_START,
                         KNOB_SWIPE_THRESHOLD,
                         SWIPE_HINT_TRAVEL);
     if (inset > (SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL)) {
@@ -244,19 +240,19 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
     symbol = LV_SYMBOL_LEFT;
 
     switch (direction) {
-    case SWIPE_HINT_RIGHT:
+    case KNOB_SWIPE_RIGHT:
         symbol = LV_SYMBOL_RIGHT;
         pos_x = inset;
         break;
-    case SWIPE_HINT_LEFT:
+    case KNOB_SWIPE_LEFT:
         symbol = LV_SYMBOL_LEFT;
         pos_x = width - SWIPE_HINT_SIZE - inset;
         break;
-    case SWIPE_HINT_DOWN:
+    case KNOB_SWIPE_DOWN:
         symbol = LV_SYMBOL_DOWN;
         pos_y = inset;
         break;
-    case SWIPE_HINT_UP:
+    case KNOB_SWIPE_UP:
         symbol = LV_SYMBOL_UP;
         pos_y = height - SWIPE_HINT_SIZE - inset;
         break;
@@ -279,6 +275,21 @@ static void open_menu_for_screen(lv_obj_t *screen)
     if (is_player_screen(screen)) {
         previous_screen = screen;
         open_quad_menu();
+    }
+}
+
+static void handle_back_navigation(lv_obj_t *screen);
+
+static void handle_swipe_navigation(knob_swipe_direction_t direction, lv_obj_t *screen)
+{
+    if (screen == NULL) return;
+
+    if (direction == KNOB_SWIPE_NONE) return;
+
+    if (is_player_screen(screen)) {
+        open_menu_for_screen(screen);
+    } else if (direction == KNOB_SWIPE_LEFT || direction == KNOB_SWIPE_DOWN) {
+        handle_back_navigation(screen);
     }
 }
 
@@ -505,39 +516,26 @@ void knob_change(knob_event_t k, int cont)
 void knob_process_pending(void)
 {
     uint8_t processed = 0;
+    lv_obj_t *cur = lv_scr_act();
 
     if (swipe_up_pending) {
         swipe_up_pending = false;
-        open_menu_for_screen(lv_scr_act());
+        handle_swipe_navigation(KNOB_SWIPE_UP, cur);
     }
 
     if (swipe_down_pending) {
-        lv_obj_t *cur;
-
         swipe_down_pending = false;
-        cur = lv_scr_act();
-
-        if (is_player_screen(cur))
-            open_menu_for_screen(cur);
-        else
-            handle_back_navigation(cur);
+        handle_swipe_navigation(KNOB_SWIPE_DOWN, cur);
     }
 
     if (swipe_left_pending) {
-        lv_obj_t *cur;
-
         swipe_left_pending = false;
-        cur = lv_scr_act();
-
-        if (is_player_screen(cur))
-            open_menu_for_screen(cur);
-        else
-            handle_back_navigation(cur);
+        handle_swipe_navigation(KNOB_SWIPE_LEFT, cur);
     }
 
     if (swipe_right_pending) {
         swipe_right_pending = false;
-        open_menu_for_screen(lv_scr_act());
+        handle_swipe_navigation(KNOB_SWIPE_RIGHT, cur);
     }
 
     while (knob_event_tail != knob_event_head && processed < 8U) {

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -29,6 +29,9 @@ static volatile bool swipe_right_pending = false;
 #define SWIPE_HINT_REVEAL_START 12
 #define SWIPE_HINT_TOP_EDGE_ZONE 80
 #define SWIPE_HINT_BOTTOM_EDGE_ZONE 80
+#define SWIPE_HINT_OPACITY_MAX 255
+#define SWIPE_HINT_OPACITY_MIN 48
+#define SWIPE_HINT_BG_OPACITY_MAX 120
 
 typedef enum {
     SWIPE_HINT_NONE = 0,
@@ -72,7 +75,7 @@ static bool is_player_screen(lv_obj_t *screen)
            screen == screen_multiplayer;
 }
 
-static int clamp_coord(int value, int min_value, int max_value)
+static int clamp_value(int value, int min_value, int max_value)
 {
     if (value < min_value) return min_value;
     if (value > max_value) return max_value;
@@ -218,16 +221,16 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
 
     width = get_display_width();
     height = get_display_height();
-    progress = ((distance - SWIPE_HINT_REVEAL_START) * 255) / (KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START);
-    if (progress < 48) progress = 48;
-    if (progress > 255) progress = 255;
+    progress = ((distance - SWIPE_HINT_REVEAL_START) * SWIPE_HINT_OPACITY_MAX) / (KNOB_SWIPE_THRESHOLD - SWIPE_HINT_REVEAL_START);
+    if (progress < SWIPE_HINT_OPACITY_MIN) progress = SWIPE_HINT_OPACITY_MIN;
+    if (progress > SWIPE_HINT_OPACITY_MAX) progress = SWIPE_HINT_OPACITY_MAX;
     inset = SWIPE_HINT_EDGE_INSET + ((distance - SWIPE_HINT_REVEAL_START) * SWIPE_HINT_TRAVEL) / KNOB_SWIPE_THRESHOLD;
     if (inset > (SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL)) {
         inset = SWIPE_HINT_EDGE_INSET + SWIPE_HINT_TRAVEL;
     }
 
-    pos_x = clamp_coord(start_x - (SWIPE_HINT_SIZE / 2), SWIPE_HINT_EDGE_INSET, width - SWIPE_HINT_SIZE - SWIPE_HINT_EDGE_INSET);
-    pos_y = clamp_coord(start_y - (SWIPE_HINT_SIZE / 2), SWIPE_HINT_EDGE_INSET, height - SWIPE_HINT_SIZE - SWIPE_HINT_EDGE_INSET);
+    pos_x = clamp_value(start_x - (SWIPE_HINT_SIZE / 2), SWIPE_HINT_EDGE_INSET, width - SWIPE_HINT_SIZE - SWIPE_HINT_EDGE_INSET);
+    pos_y = clamp_value(start_y - (SWIPE_HINT_SIZE / 2), SWIPE_HINT_EDGE_INSET, height - SWIPE_HINT_SIZE - SWIPE_HINT_EDGE_INSET);
     symbol = LV_SYMBOL_LEFT;
 
     switch (direction) {
@@ -253,7 +256,7 @@ void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y)
 
     lv_label_set_text(swipe_hint_icon, symbol);
     lv_obj_set_pos(swipe_hint, pos_x, pos_y);
-    lv_obj_set_style_bg_opa(swipe_hint, (lv_opa_t)((progress * 120) / 255), 0);
+    lv_obj_set_style_bg_opa(swipe_hint, (lv_opa_t)((progress * SWIPE_HINT_BG_OPACITY_MAX) / SWIPE_HINT_OPACITY_MAX), 0);
     lv_obj_set_style_text_opa(swipe_hint_icon, (lv_opa_t)progress, 0);
     lv_obj_clear_flag(swipe_hint, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_foreground(swipe_hint);

--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -9,12 +9,19 @@ extern "C"
 #include "lvgl.h"
 #include "bidi_switch_knob.h"
 
+#define KNOB_SWIPE_THRESHOLD 80
+#define KNOB_SWIPE_MAX_LATERAL 120
+#define KNOB_SWIPE_LEFT_EDGE_ZONE 80
+#define KNOB_SWIPE_RIGHT_EDGE_ZONE 80
+
 void knob_gui(void);
 void knob_cb(lv_event_t *e);
 
 void knob_change(knob_event_t k,int cont);
 void knob_process_pending(void);
 bool activity_kick(void);
+void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y);
+void knob_swipe_hint_clear(void);
 void knob_notify_swipe_up(void);
 void knob_notify_swipe_down(void);
 void knob_notify_swipe_left(void);

--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -41,6 +41,9 @@ knob_swipe_direction_t knob_classify_swipe_direction(lv_obj_t *screen,
 													 int min_travel);
 void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y);
 void knob_swipe_hint_clear(void);
+bool knob_swipe_hint_fully_revealed(lv_obj_t *screen,
+									int start_x, int start_y,
+									int cur_x, int cur_y);
 void knob_notify_swipe_up(void);
 void knob_notify_swipe_down(void);
 void knob_notify_swipe_left(void);

--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -9,10 +9,25 @@ extern "C"
 #include "lvgl.h"
 #include "bidi_switch_knob.h"
 
-#define KNOB_SWIPE_THRESHOLD 80
-#define KNOB_SWIPE_MAX_LATERAL 120
-#define KNOB_SWIPE_LEFT_EDGE_ZONE 80
-#define KNOB_SWIPE_RIGHT_EDGE_ZONE 80
+typedef enum {
+	KNOB_SWIPE_NONE = 0,
+	KNOB_SWIPE_LEFT,
+	KNOB_SWIPE_RIGHT,
+	KNOB_SWIPE_UP,
+	KNOB_SWIPE_DOWN
+} knob_swipe_direction_t;
+
+#define KNOB_TOUCH_JITTER_PX 14
+#define KNOB_SWIPE_THRESHOLD 84
+#define KNOB_SWIPE_HINT_REVEAL_START 28
+#define KNOB_SWIPE_MAX_LATERAL 72
+#define KNOB_SWIPE_MIN_DURATION_MS 100
+#define KNOB_SWIPE_LEFT_EDGE_ZONE 56
+#define KNOB_SWIPE_RIGHT_EDGE_ZONE 56
+#define KNOB_SWIPE_TOP_EDGE_ZONE 56
+#define KNOB_SWIPE_BOTTOM_EDGE_ZONE 56
+#define KNOB_SWIPE_AXIS_BIAS_NUM 3
+#define KNOB_SWIPE_AXIS_BIAS_DEN 2
 
 void knob_gui(void);
 void knob_cb(lv_event_t *e);
@@ -20,6 +35,10 @@ void knob_cb(lv_event_t *e);
 void knob_change(knob_event_t k,int cont);
 void knob_process_pending(void);
 bool activity_kick(void);
+knob_swipe_direction_t knob_classify_swipe_direction(lv_obj_t *screen,
+													 int start_x, int start_y,
+													 int dx, int dy,
+													 int min_travel);
 void knob_swipe_hint_update(int start_x, int start_y, int cur_x, int cur_y);
 void knob_swipe_hint_clear(void);
 void knob_notify_swipe_up(void);

--- a/knobby/lv_conf.h
+++ b/knobby/lv_conf.h
@@ -82,7 +82,14 @@
 #define LV_DISP_DEF_REFR_PERIOD 25      /*[ms]*/
 
 /*Input device read period in milliseconds*/
-#define LV_INDEV_DEF_READ_PERIOD 50     /*[ms]*/
+#define LV_INDEV_DEF_READ_PERIOD 35     /*[ms]*/
+
+/*Pointer motion tolerance before LVGL treats the gesture as a drag.*/
+#define LV_INDEV_DEF_DRAG_LIMIT 14      /*[px]*/
+
+/*Balanced hold time so long presses stay distinct from taps and swipes.*/
+#define LV_INDEV_DEF_LONG_PRESS_TIME 500    /*[ms]*/
+#define LV_INDEV_DEF_LONG_PRESS_REP_TIME 250 /*[ms]*/
 
 /*Use a custom tick source that tells the elapsed time in milliseconds.
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -296,11 +296,6 @@ static bool tp_tracking = false;
 static bool tp_swiped = false;
 static lv_point_t tp_start = {0, 0};
 
-#define SWIPE_THRESHOLD 80
-#define SWIPE_MAX_LATERAL 120
-#define SWIPE_LEFT_EDGE_ZONE 80
-#define SWIPE_RIGHT_EDGE_ZONE 80
-
 static bool check_swipe(int cur_x, int cur_y)
 {
   int dx = cur_x - tp_start.x;
@@ -308,25 +303,29 @@ static bool check_swipe(int cur_x, int cur_y)
   int abs_dx = dx >= 0 ? dx : -dx;
   int abs_dy = dy >= 0 ? dy : -dy;
 
-  if (-dy > SWIPE_THRESHOLD && abs_dx < SWIPE_MAX_LATERAL) {
+  if (-dy > KNOB_SWIPE_THRESHOLD && abs_dx < KNOB_SWIPE_MAX_LATERAL) {
+    knob_swipe_hint_clear();
     knob_notify_swipe_up();
     lv_indev_reset(lv_indev_get_act(), NULL);
     return true;
-  } else if (dy > SWIPE_THRESHOLD && abs_dx < SWIPE_MAX_LATERAL) {
+  } else if (dy > KNOB_SWIPE_THRESHOLD && abs_dx < KNOB_SWIPE_MAX_LATERAL) {
+    knob_swipe_hint_clear();
     knob_notify_swipe_down();
     lv_indev_reset(lv_indev_get_act(), NULL);
     return true;
-  } else if (tp_start.x >= (SCREEN_RES_HOR - SWIPE_RIGHT_EDGE_ZONE) &&
-             -dx > SWIPE_THRESHOLD &&
-             abs_dy < SWIPE_MAX_LATERAL &&
+  } else if (tp_start.x >= (SCREEN_RES_HOR - KNOB_SWIPE_RIGHT_EDGE_ZONE) &&
+             -dx > KNOB_SWIPE_THRESHOLD &&
+             abs_dy < KNOB_SWIPE_MAX_LATERAL &&
              -dx > abs_dy) {
+    knob_swipe_hint_clear();
     knob_notify_swipe_left();
     lv_indev_reset(lv_indev_get_act(), NULL);
     return true;
-  } else if (tp_start.x <= SWIPE_LEFT_EDGE_ZONE &&
-             dx > SWIPE_THRESHOLD &&
-             abs_dy < SWIPE_MAX_LATERAL &&
+  } else if (tp_start.x <= KNOB_SWIPE_LEFT_EDGE_ZONE &&
+             dx > KNOB_SWIPE_THRESHOLD &&
+             abs_dy < KNOB_SWIPE_MAX_LATERAL &&
              dx > abs_dy) {
+    knob_swipe_hint_clear();
     knob_notify_swipe_right();
     lv_indev_reset(lv_indev_get_act(), NULL);
     return true;
@@ -353,6 +352,7 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
       // Reset swipe context on wake, but don't discard the touch
       tp_tracking = false;
       tp_swiped = false;
+      knob_swipe_hint_clear();
     }
     if (tp_swiped) {
       data->state = LV_INDEV_STATE_RELEASED;
@@ -364,9 +364,12 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
         tp_start.x = point.x;
         tp_start.y = point.y;
         tp_tracking = true;
-      } else if (check_swipe(point.x, point.y)) {
-        tp_swiped = true;
-        data->state = LV_INDEV_STATE_RELEASED;
+      } else {
+        knob_swipe_hint_update(tp_start.x, tp_start.y, point.x, point.y);
+        if (check_swipe(point.x, point.y)) {
+          tp_swiped = true;
+          data->state = LV_INDEV_STATE_RELEASED;
+        }
       }
     }
   }
@@ -377,6 +380,7 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
     }
     tp_tracking = false;
     tp_swiped = false;
+    knob_swipe_hint_clear();
     data->state = LV_INDEV_STATE_RELEASED;
   }
 }

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -7,6 +7,7 @@
 #include <ESP_Panel_Library.h>
 // #include "bidi_switch_knob.h"
 #include "knob.h"
+#include "src/hw.h"
 
 #define SCREEN_RES_HOR 360
 #define SCREEN_RES_VER 360
@@ -295,41 +296,63 @@ void scr_display_on(void)
 static bool tp_tracking = false;
 static bool tp_swiped = false;
 static lv_point_t tp_start = {0, 0};
+static lv_point_t tp_last = {0, 0};
+static uint32_t tp_start_tick = 0;
+
+static int touch_abs(int value)
+{
+  return (value >= 0) ? value : -value;
+}
+
+static bool touch_point_valid(int x, int y)
+{
+  return x >= 0 && x < SCREEN_RES_HOR && y >= 0 && y < SCREEN_RES_VER;
+}
+
+static void touch_reset_state(void)
+{
+  tp_tracking = false;
+  tp_swiped = false;
+  tp_start.x = 0;
+  tp_start.y = 0;
+  tp_last.x = 0;
+  tp_last.y = 0;
+  tp_start_tick = 0;
+  knob_swipe_hint_clear();
+}
 
 static bool check_swipe(int cur_x, int cur_y)
 {
+  knob_swipe_direction_t direction;
   int dx = cur_x - tp_start.x;
   int dy = cur_y - tp_start.y;
-  int abs_dx = dx >= 0 ? dx : -dx;
-  int abs_dy = dy >= 0 ? dy : -dy;
+  if (!tp_tracking || tp_start_tick == 0) return false;
+  if (!touch_point_valid(cur_x, cur_y)) return false;
+  if (in_undim_grace()) return false;
 
-  if (-dy > KNOB_SWIPE_THRESHOLD && abs_dx < KNOB_SWIPE_MAX_LATERAL) {
-    knob_swipe_hint_clear();
-    knob_notify_swipe_up();
-    lv_indev_reset(lv_indev_get_act(), NULL);
-    return true;
-  } else if (dy > KNOB_SWIPE_THRESHOLD && abs_dx < KNOB_SWIPE_MAX_LATERAL) {
-    knob_swipe_hint_clear();
-    knob_notify_swipe_down();
-    lv_indev_reset(lv_indev_get_act(), NULL);
-    return true;
-  } else if (tp_start.x >= (SCREEN_RES_HOR - KNOB_SWIPE_RIGHT_EDGE_ZONE) &&
-             -dx > KNOB_SWIPE_THRESHOLD &&
-             abs_dy < KNOB_SWIPE_MAX_LATERAL &&
-             -dx > abs_dy) {
-    knob_swipe_hint_clear();
-    knob_notify_swipe_left();
-    lv_indev_reset(lv_indev_get_act(), NULL);
-    return true;
-  } else if (tp_start.x <= KNOB_SWIPE_LEFT_EDGE_ZONE &&
-             dx > KNOB_SWIPE_THRESHOLD &&
-             abs_dy < KNOB_SWIPE_MAX_LATERAL &&
-             dx > abs_dy) {
-    knob_swipe_hint_clear();
-    knob_notify_swipe_right();
-    lv_indev_reset(lv_indev_get_act(), NULL);
-    return true;
+  if (touch_abs(dx) < KNOB_TOUCH_JITTER_PX && touch_abs(dy) < KNOB_TOUCH_JITTER_PX) {
+    return false;
   }
+
+  if (lv_tick_elaps(tp_start_tick) < KNOB_SWIPE_MIN_DURATION_MS) return false;
+
+  direction = knob_classify_swipe_direction(lv_scr_act(), tp_start.x, tp_start.y,
+                                            dx, dy, KNOB_SWIPE_THRESHOLD);
+  if (direction == KNOB_SWIPE_NONE) return false;
+
+  knob_swipe_hint_clear();
+  if (direction == KNOB_SWIPE_UP) {
+    knob_notify_swipe_up();
+  } else if (direction == KNOB_SWIPE_DOWN) {
+    knob_notify_swipe_down();
+  } else if (direction == KNOB_SWIPE_LEFT) {
+    knob_notify_swipe_left();
+  } else if (direction == KNOB_SWIPE_RIGHT) {
+    knob_notify_swipe_right();
+  }
+  lv_indev_reset(lv_indev_get_act(), NULL);
+  return true;
+
   return false;
 }
 
@@ -347,12 +370,15 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
   touch_irq_pending = false;
   if (read_touch_result > 0)
   {
+    if (!touch_point_valid(point.x, point.y)) {
+      touch_reset_state();
+      data->state = LV_INDEV_STATE_RELEASED;
+      return;
+    }
+
     bool was_dimmed = activity_kick();
     if (was_dimmed) {
-      // Reset swipe context on wake, but don't discard the touch
-      tp_tracking = false;
-      tp_swiped = false;
-      knob_swipe_hint_clear();
+      touch_reset_state();
     }
     if (tp_swiped) {
       data->state = LV_INDEV_STATE_RELEASED;
@@ -363,8 +389,12 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
       if (!tp_tracking) {
         tp_start.x = point.x;
         tp_start.y = point.y;
+        tp_last = tp_start;
+        tp_start_tick = lv_tick_get();
         tp_tracking = true;
       } else {
+        tp_last.x = point.x;
+        tp_last.y = point.y;
         knob_swipe_hint_update(tp_start.x, tp_start.y, point.x, point.y);
         if (check_swipe(point.x, point.y)) {
           tp_swiped = true;
@@ -375,12 +405,10 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
   }
   else
   {
-    if (tp_tracking && !tp_swiped) {
-      check_swipe(data->point.x, data->point.y);
+    if (tp_tracking && !tp_swiped && touch_point_valid(tp_last.x, tp_last.y)) {
+      check_swipe(tp_last.x, tp_last.y);
     }
-    tp_tracking = false;
-    tp_swiped = false;
-    knob_swipe_hint_clear();
+    touch_reset_state();
     data->state = LV_INDEV_STATE_RELEASED;
   }
 }

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -339,6 +339,10 @@ static bool check_swipe(int cur_x, int cur_y)
   direction = knob_classify_swipe_direction(lv_scr_act(), tp_start.x, tp_start.y,
                                             dx, dy, KNOB_SWIPE_THRESHOLD);
   if (direction == KNOB_SWIPE_NONE) return false;
+  if (!knob_swipe_hint_fully_revealed(lv_scr_act(), tp_start.x, tp_start.y,
+                                      cur_x, cur_y)) {
+    return false;
+  }
 
   knob_swipe_hint_clear();
   if (direction == KNOB_SWIPE_UP) {
@@ -396,17 +400,13 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
         tp_last.x = point.x;
         tp_last.y = point.y;
         knob_swipe_hint_update(tp_start.x, tp_start.y, point.x, point.y);
-        if (check_swipe(point.x, point.y)) {
-          tp_swiped = true;
-          data->state = LV_INDEV_STATE_RELEASED;
-        }
       }
     }
   }
   else
   {
     if (tp_tracking && !tp_swiped && touch_point_valid(tp_last.x, tp_last.y)) {
-      check_swipe(tp_last.x, tp_last.y);
+      tp_swiped = check_swipe(tp_last.x, tp_last.y);
     }
     touch_reset_state();
     data->state = LV_INDEV_STATE_RELEASED;

--- a/knobby/src/dice.c
+++ b/knobby/src/dice.c
@@ -76,7 +76,7 @@ void build_dice_screen(void)
     lv_obj_align(label_dice_result, LV_ALIGN_CENTER, 0, -10);
 
     label_dice_hint = lv_label_create(screen_dice);
-    lv_label_set_text(label_dice_hint, "long press to re-roll");
+    lv_label_set_text(label_dice_hint, "Hold to re-roll");
     lv_obj_set_style_text_color(label_dice_hint, lv_color_hex(0x8A8A8A), 0);
     lv_obj_set_style_text_font(label_dice_hint, &lv_font_montserrat_14, 0);
     lv_obj_align(label_dice_hint, LV_ALIGN_CENTER, 0, 42);

--- a/knobby/src/game_mode.c
+++ b/knobby/src/game_mode.c
@@ -136,8 +136,8 @@ void build_game_mode_menu_screen(void)
     quad_item_t items[4] = {
         {"Players\n4",          event_gm_num_players,      true, LV_EVENT_CLICKED},
         {"Track\n1",            event_gm_players_to_track, true, LV_EVENT_CLICKED},
-        {"Life\n40",            event_gm_life_cycle,       true, LV_EVENT_CLICKED},
-        {"Apply\n(Long Press)", event_gm_apply,            true, LV_EVENT_LONG_PRESSED},
+        {"Life\n40",            event_gm_life_cycle,       true, LV_EVENT_SHORT_CLICKED},
+        {"Apply\n(Hold)",       event_gm_apply,            true, LV_EVENT_LONG_PRESSED},
     };
     build_quad_screen(&screen_game_mode_menu, items);
 

--- a/knobby/src/hw.h
+++ b/knobby/src/hw.h
@@ -19,7 +19,7 @@ extern int battery_percent;
 // Reducing AUTO_DIM_BRIGHTNESS below 5 further cuts backlight draw while dimmed.
 #define AUTO_DIM_BRIGHTNESS     5       /* % brightness while dimmed */
 // UNDIM_GRACE_MS suppresses input for this long after wake to avoid accidental presses.
-#define UNDIM_GRACE_MS          150     /* ms */
+#define UNDIM_GRACE_MS          225     /* ms */
 #define CPU_FREQ_ACTIVE         160     /* MHz – APB bus stays 80 MHz at 80/160/240 */
 // Battery sample throttle: how often a fresh ADC measurement is allowed.
 #define BATTERY_SAMPLE_INTERVAL_MS  60000   /* ms between passive battery measurements */

--- a/knobby/src/mana.c
+++ b/knobby/src/mana.c
@@ -261,7 +261,7 @@ void build_mana_screen(void)
         lv_obj_add_event_cb(btn, event_mana_clear, LV_EVENT_LONG_PRESSED, NULL);
 
         label = lv_label_create(btn);
-        lv_label_set_text(label, "Clear All\n(Long Press)");
+        lv_label_set_text(label, "Clear All\n(Hold)");
         lv_obj_set_style_text_color(label, lv_color_white(), 0);
         lv_obj_set_style_text_font(label, &lv_font_montserrat_14, 0);
         lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -360,7 +360,7 @@ void build_quad_menus(void)
         {"Settings", event_quad_screen_settings, true, LV_EVENT_CLICKED},
         {"Game\nMode", event_general_game_mode, true, LV_EVENT_CLICKED},
         {"Tools",             event_quad_tools, true, LV_EVENT_CLICKED},
-        {"Reset\n(Long Press)", event_general_reset, true, LV_EVENT_LONG_PRESSED},
+        {"Reset\n(Hold)", event_general_reset, true, LV_EVENT_LONG_PRESSED},
     };
     build_quad_screen(&screen_quad_menu, main_items);
 

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -537,7 +537,7 @@ void rebuild_multiplayer_layout(int track)
         lv_obj_set_style_border_width(panel, 1, 0);
         lv_obj_set_style_border_color(panel, lv_color_black(), 0);
         lv_obj_set_style_shadow_width(panel, 0, 0);
-        lv_obj_add_event_cb(panel, event_multiplayer_select, LV_EVENT_CLICKED, (void *)(intptr_t)p);
+        lv_obj_add_event_cb(panel, event_multiplayer_select, LV_EVENT_SHORT_CLICKED, (void *)(intptr_t)p);
         lv_obj_add_event_cb(panel, event_multiplayer_open_menu, LV_EVENT_LONG_PRESSED, (void *)(intptr_t)p);
         mp_state.panels[i] = panel;
 

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -470,9 +470,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
         life_preview_commit_cb(NULL);
     }
 
-    selected_player = player;
-    refresh_multiplayer_ui();
-    open_player_menu(selected_player);
+    open_player_menu(player);
     lv_indev_wait_release(lv_indev_get_act());
 }
 

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -458,6 +458,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
     int player = (int)(intptr_t)lv_event_get_user_data(e);
 
     if (player < 0 || player >= MULTIPLAYER_COUNT) return;
+    if (selected_player >= 0) return;
     if (player_eliminated[player]) {
         menu_player = player;
         load_screen_if_needed(screen_eliminated_player_menu);


### PR DESCRIPTION
Added visual indicator for swipe action. Swipe only registers if indicator is fully visible when touch removed.

Refine distinction between swipe, short press, long press a bit.

Closes #63 