### PR TITLE
Allow long-press to open a player's menu while a player is selected

### DIFF
--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -458,7 +458,11 @@ static void event_multiplayer_open_menu(lv_event_t *e)
     int player = (int)(intptr_t)lv_event_get_user_data(e);
 
     if (player < 0 || player >= MULTIPLAYER_COUNT) return;
-    if (selected_player >= 0) return;
+
+    /* A long-press is a deliberate gesture, so it always opens the
+       pressed player's menu (e.g. to apply commander damage), even when
+       another player is selected for life changes; the selection is left
+       untouched. */
     if (player_eliminated[player]) {
         menu_player = player;
         load_screen_if_needed(screen_eliminated_player_menu);
@@ -466,7 +470,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
         return;
     }
 
-    if (life_preview_active && preview_player != player) {
+    if (life_preview_active) {
         life_preview_commit_cb(NULL);
     }
 


### PR DESCRIPTION
On the multiplayer screen, `event_multiplayer_open_menu()` bailed out whenever a player was selected for life changes (`if (selected_player >= 0) return;`). That meant applying commander damage to a selected player required deselecting first.

A long-press is a deliberate gesture, so it should always open the pressed player's menu. This change:
- Removes the early `selected_player >= 0` bail-out; the long-press opens the pressed player's menu and leaves the current selection untouched.
- Simplifies the preview-commit guard to commit any active life preview before opening the menu (previously only committed when the preview belonged to a different player).

Interaction-behavior change only — no widget layout change, so no screenshot-matrix diff.