### PR TITLE
Fix elimination and undo lifecycle bugs

### DIFF
--- a/knobby/bidi_switch_knob.c
+++ b/knobby/bidi_switch_knob.c
@@ -167,46 +167,6 @@ _encoder_deinit:
     return NULL;
 }
 
-esp_err_t iot_knob_delete(knob_handle_t knob_handle)
-{
-    esp_err_t ret = ESP_OK;
-    KNOB_CHECK(NULL != knob_handle, "Pointer of handle is invalid", ESP_ERR_INVALID_ARG);
-    knob_dev_t *knob = (knob_dev_t *)knob_handle;
-    ret = knob_gpio_deinit((int)(knob->usr_data));
-    KNOB_CHECK(ESP_OK == ret, "knob deinit failed", ESP_FAIL);
-    knob_dev_t **curr;
-    for (curr = &s_head_handle; *curr;)
-    {
-        knob_dev_t *entry = *curr;
-        if (entry == knob)
-        {
-            *curr = entry->next;
-            free(entry);
-        }
-        else
-        {
-            curr = &entry->next;
-        }
-    }
-
-    uint16_t number = 0;
-    knob_dev_t *target = s_head_handle;
-    while (target)
-    {
-        target = target->next;
-        number++;
-    }
-    ESP_LOGD(TAG, "remain knob number=%d", number);
-
-    if (0 == number && s_is_timer_running)
-    {
-        esp_timer_stop(s_knob_timer_handle);
-        esp_timer_delete(s_knob_timer_handle);
-        s_is_timer_running = false;
-    }
-
-    return ESP_OK;
-}
 
 esp_err_t iot_knob_register_cb(knob_handle_t knob_handle, knob_event_t event, knob_cb_t cb, void *usr_data)
 {

--- a/knobby/bidi_switch_knob.h
+++ b/knobby/bidi_switch_knob.h
@@ -60,7 +60,6 @@ extern "C"
      *         - ESP_OK  Success
      *         - ESP_FAIL Failure
      */
-    esp_err_t iot_knob_delete(knob_handle_t knob_handle);
 
     /**
      * @brief Register the knob event callback function

--- a/knobby/board_detect.c
+++ b/knobby/board_detect.c
@@ -20,27 +20,8 @@
  * Detection probes CST816S touch (addr 0x15) on each candidate's I2C pins.
  * First board whose touch responds wins, so put the most common board first. */
 
-const board_pins_t board_k518 = {
-    .name       = "JC3636K518",
-    .tft_blk    = 47,  .tft_rst  = 21,  .tft_cs  = 14,  .tft_sck = 13,
-    .tft_sda0   = 15,  .tft_sda1 = 16,  .tft_sda2 = 17, .tft_sda3 = 18,
-    .touch_scl  = 12,  .touch_sda = 11, .touch_int = 9,  .touch_rst = 10,
-    .enc_a      = 8,   .enc_b    = 7,
-    .bat_adc    = 1,
-    .btn        = 0,
-    .mirror_x   = false, .mirror_y = false,
-};
-
-const board_pins_t board_k718 = {
-    .name       = "JC3636K718",
-    .tft_blk    = 21,  .tft_rst  = 17,  .tft_cs  = 12,  .tft_sck = 11,
-    .tft_sda0   = 13,  .tft_sda1 = 14,  .tft_sda2 = 15, .tft_sda3 = 16,
-    .touch_scl  = 10,  .touch_sda = 9,  .touch_int = 7,  .touch_rst = 8,
-    .enc_a      = 1,   .enc_b    = 2,
-    .bat_adc    = 6,
-    .btn        = 0,
-    .mirror_x   = true,  .mirror_y = true,
-};
+/* board_k518 / board_k718 pin tables live in board_pins.c (shared with
+ * the simulator build). */
 
 /* Candidates to probe, in order. First match wins. */
 static const board_pins_t *candidates[] = {

--- a/knobby/board_pins.c
+++ b/knobby/board_pins.c
@@ -1,0 +1,28 @@
+/* Per-board pin tables, compiled into BOTH the firmware and the
+ * simulator so the data cannot drift between them. The I2C probe that
+ * selects a table at boot lives in board_detect.c (firmware only);
+ * the simulator stubs the probe in sim/sim_stubs.c. */
+
+#include "board_detect.h"
+
+const board_pins_t board_k518 = {
+    .name       = "JC3636K518",
+    .tft_blk    = 47,  .tft_rst  = 21,  .tft_cs  = 14,  .tft_sck = 13,
+    .tft_sda0   = 15,  .tft_sda1 = 16,  .tft_sda2 = 17, .tft_sda3 = 18,
+    .touch_scl  = 12,  .touch_sda = 11, .touch_int = 9,  .touch_rst = 10,
+    .enc_a      = 8,   .enc_b    = 7,
+    .bat_adc    = 1,
+    .btn        = 0,
+    .mirror_x   = false, .mirror_y = false,
+};
+
+const board_pins_t board_k718 = {
+    .name       = "JC3636K718",
+    .tft_blk    = 21,  .tft_rst  = 17,  .tft_cs  = 12,  .tft_sck = 11,
+    .tft_sda0   = 13,  .tft_sda1 = 14,  .tft_sda2 = 15, .tft_sda3 = 16,
+    .touch_scl  = 10,  .touch_sda = 9,  .touch_int = 7,  .touch_rst = 8,
+    .enc_a      = 1,   .enc_b    = 2,
+    .bat_adc    = 6,
+    .btn        = 0,
+    .mirror_x   = true,  .mirror_y = true,
+};

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -31,8 +31,6 @@ static volatile bool swipe_right_pending = false;
 #define SWIPE_HINT_BG_OPACITY_MAX 120
 
 // ---------- knob event queue ----------
-static int last_knob_cont = 0;
-static bool knob_initialized = false;
 static knob_input_event_t knob_event_queue[KNOB_EVENT_QUEUE_SIZE];
 static volatile uint8_t knob_event_head = 0;
 static volatile uint8_t knob_event_tail = 0;
@@ -385,10 +383,6 @@ void reset_all_values(void)
     start_player_selection_animation();
 }
 
-void knob_cb(lv_event_t *e)
-{
-    (void)e;
-}
 
 // ---------- init ----------
 void knob_gui(void)
@@ -511,13 +505,7 @@ void knob_change(knob_event_t k, int cont)
 {
     uint8_t next_head;
 
-    if (!knob_initialized)
-    {
-        last_knob_cont = cont;
-        knob_initialized = true;
-    }
-
-    last_knob_cont = cont;
+    (void)cont;
 
     next_head = (uint8_t)((knob_event_head + 1U) % KNOB_EVENT_QUEUE_SIZE);
     if (next_head == knob_event_tail) {
@@ -525,7 +513,6 @@ void knob_change(knob_event_t k, int cont)
     }
 
     knob_event_queue[knob_event_head].event = k;
-    knob_event_queue[knob_event_head].cont = cont;
     knob_event_head = next_head;
 }
 

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -32,8 +32,8 @@ static volatile bool swipe_right_pending = false;
 
 // ---------- knob event queue ----------
 static knob_input_event_t knob_event_queue[KNOB_EVENT_QUEUE_SIZE];
-static volatile uint8_t knob_event_head = 0;
-static volatile uint8_t knob_event_tail = 0;
+static uint8_t knob_event_head = 0;  /* producer (encoder task) owns */
+static uint8_t knob_event_tail = 0;  /* consumer (main loop) owns */
 
 // ---------- swipe notifications ----------
 void knob_notify_swipe_up(void)
@@ -501,19 +501,23 @@ static void handle_knob_event(knob_event_t k)
     }
 }
 
-void knob_change(knob_event_t k, int cont)
+/* Producer: runs in the encoder esp_timer task, possibly on the other
+   core. Single-producer/single-consumer ring — only this side writes head,
+   only the consumer writes tail. On overflow the new detent is dropped
+   rather than advancing the consumer's tail (which would race it). */
+void knob_change(knob_event_t k)
 {
-    uint8_t next_head;
+    uint8_t head = __atomic_load_n(&knob_event_head, __ATOMIC_RELAXED);
+    uint8_t tail = __atomic_load_n(&knob_event_tail, __ATOMIC_ACQUIRE);
+    uint8_t next_head = (uint8_t)((head + 1U) % KNOB_EVENT_QUEUE_SIZE);
 
-    (void)cont;
-
-    next_head = (uint8_t)((knob_event_head + 1U) % KNOB_EVENT_QUEUE_SIZE);
-    if (next_head == knob_event_tail) {
-        knob_event_tail = (uint8_t)((knob_event_tail + 1U) % KNOB_EVENT_QUEUE_SIZE);
+    if (next_head == tail) {
+        return;  /* queue full: drop the newest detent */
     }
 
-    knob_event_queue[knob_event_head].event = k;
-    knob_event_head = next_head;
+    knob_event_queue[head].event = k;
+    /* Release so the consumer's acquire-load of head sees the slot write. */
+    __atomic_store_n(&knob_event_head, next_head, __ATOMIC_RELEASE);
 }
 
 void knob_process_pending(void)
@@ -541,9 +545,12 @@ void knob_process_pending(void)
         handle_swipe_navigation(KNOB_SWIPE_RIGHT, cur);
     }
 
-    while (knob_event_tail != knob_event_head && processed < 8U) {
-        knob_event_t event = knob_event_queue[knob_event_tail].event;
-        knob_event_tail = (uint8_t)((knob_event_tail + 1U) % KNOB_EVENT_QUEUE_SIZE);
+    uint8_t head = __atomic_load_n(&knob_event_head, __ATOMIC_ACQUIRE);
+    uint8_t tail = __atomic_load_n(&knob_event_tail, __ATOMIC_RELAXED);
+    while (tail != head && processed < 8U) {
+        knob_event_t event = knob_event_queue[tail].event;
+        tail = (uint8_t)((tail + 1U) % KNOB_EVENT_QUEUE_SIZE);
+        __atomic_store_n(&knob_event_tail, tail, __ATOMIC_RELEASE);
         handle_knob_event(event);
         processed++;
     }

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -324,16 +324,8 @@ static void handle_back_navigation(lv_obj_t *screen)
         lv_scr_load(previous_screen);
     } else if (screen == screen_tools_menu) {
         lv_scr_load(screen_quad_menu);
-    } else if (screen == screen_screen_settings_menu) {
-        settings_save();
-        lv_scr_load(screen_quad_menu);
-    } else if (screen == screen_settings_page2) {
-        lv_scr_load(screen_screen_settings_menu);
-    } else if (screen == screen_settings) {
-        settings_save();
-        lv_scr_load(screen_screen_settings_menu);
-    } else if (screen == screen_battery) {
-        lv_scr_load(screen_screen_settings_menu);
+    } else if (settings_handle_back(screen)) {
+        /* settings pages and their sub-screens (brightness, battery) */
     } else if (screen == screen_dice) {
         lv_scr_load(screen_tools_menu);
     } else if (screen == screen_damage_log) {

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -72,7 +72,7 @@ static int clamp_value(int value, int min_value, int max_value)
 static int scale_value(int value, int input_max, int output_max)
 {
     if (value < 0 || input_max <= 0 || output_max <= 0) return 0;
-    return (int)(((int64_t)value * output_max) + (input_max / 2)) / input_max;
+    return (int)((((int64_t)value * output_max) + (input_max / 2)) / input_max);
 }
 
 static int get_display_width(void)

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -449,7 +449,7 @@ static void handle_knob_event(knob_event_t k)
     }
     else if (lv_scr_act() == screen_1p)
     {
-        selected_player = 0;
+        selection_set_single(0);
         if (k == KNOB_LEFT)      change_player_life(-1);
         else if (k == KNOB_RIGHT) change_player_life(+1);
     }

--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -30,7 +30,6 @@ typedef enum {
 #define KNOB_SWIPE_AXIS_BIAS_DEN 2
 
 void knob_gui(void);
-void knob_cb(lv_event_t *e);
 
 void knob_change(knob_event_t k,int cont);
 void knob_process_pending(void);

--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -31,7 +31,7 @@ typedef enum {
 
 void knob_gui(void);
 
-void knob_change(knob_event_t k,int cont);
+void knob_change(knob_event_t k);
 void knob_process_pending(void);
 bool activity_kick(void);
 knob_swipe_direction_t knob_classify_swipe_direction(lv_obj_t *screen,

--- a/knobby/lv_conf.h
+++ b/knobby/lv_conf.h
@@ -33,6 +33,10 @@
 /*Enable more complex drawing routines to manage screens transparency.
  *Can be used if the UI is above another layer, e.g. an OSD menu or video player.
  *Requires `LV_COLOR_DEPTH = 32` colors and the screen's `bg_opa` should be set to non LV_OPA_COVER value*/
+/* Keep this 1. The depth-32 note above marks it unsupported at 16-bit, but on
+ * hardware setting it to 0 makes the 3-player pie-wedge child labels (P2/P3
+ * life + name) disappear — the masked full-screen wedge panels rely on this
+ * transparency draw path. Verified on device. Do not 'clean up' to 0. */
 #define LV_COLOR_SCREEN_TRANSP 1
 
 /* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -279,8 +279,12 @@ static void my_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t
     return;
   }
 
-  lcd->drawBitmap(area->x1, area->y1, area->x2 - area->x1 + 1,
-                  area->y2 - area->y1 + 1, (const uint8_t *)color_p);
+  if (!lcd->drawBitmap(area->x1, area->y1, area->x2 - area->x1 + 1,
+                       area->y2 - area->y1 + 1, (const uint8_t *)color_p)) {
+    /* No transfer was queued, so onRefreshFinishCallback will never fire to
+       release LVGL — release it here to avoid a permanent flush stall. */
+    lv_disp_flush_ready(disp);
+  }
 }
 
 IRAM_ATTR bool onRefreshFinishCallback(void *user_data)
@@ -369,8 +373,10 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
     return;
   }
 
-  int read_touch_result = tp->readPoints(&point, 1);
+  /* Clear before the (multi-ms) I2C read so a touch interrupt arriving
+     mid-read is preserved for the next poll instead of being lost. */
   touch_irq_pending = false;
+  int read_touch_result = tp->readPoints(&point, 1);
   if (read_touch_result > 0)
   {
     if (!touch_point_valid(point.x, point.y)) {
@@ -380,8 +386,13 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
     }
 
     bool was_dimmed = activity_kick();
-    if (was_dimmed) {
+    if (was_dimmed || in_undim_grace()) {
+      /* The tap that wakes (or just woke) a dimmed screen must not also
+         click the widget under the finger; swallow the whole gesture for
+         the grace window, matching the swipe/encoder suppression. */
       touch_reset_state();
+      data->state = LV_INDEV_STATE_RELEASED;
+      return;
     }
     data->point.x = point.x;
     data->point.y = point.y;
@@ -551,7 +562,13 @@ void scr_lvgl_init()
   }
   size_t lv_cache_rows = STAGE_BOUNCE_ROWS;
 
-  disp_draw_buf = (lv_color_t *)heap_caps_malloc(lv_cache_rows * SCREEN_RES_HOR * 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+  disp_draw_buf = (lv_color_t *)heap_caps_malloc(lv_cache_rows * SCREEN_RES_HOR * sizeof(lv_color_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+  if (disp_draw_buf == NULL) {
+    /* Every flush writes through this buffer; a NULL here would crash on the
+       first render. frame_stage has a fallback, but this one is mandatory. */
+    Serial.printf("FATAL: display draw buffer alloc failed\n");
+    while (1) { delay(1000); }
+  }
   frame_stage = (lv_color_t *)heap_caps_malloc(
       SCREEN_RES_VER * SCREEN_RES_HOR * sizeof(lv_color_t),
       MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -18,7 +18,19 @@
 #define CONFIG_KNOB_HIGH_LIMIT     1
 #define CONFIG_KNOB_LOW_LIMIT      1
 
+#define STAGE_BOUNCE_ROWS 72
+
 static lv_color_t *disp_draw_buf;
+/* PSRAM full-frame staging: rendered bands are assembled here and pushed
+   to the panel back-to-back at SPI speed on the frame's last band, so the
+   GRAM write is one fast wipe instead of a render-paced band-by-band
+   sweep. SPI DMA cannot read PSRAM directly on this stack, so the push
+   bounces through disp_draw_buf in synchronous chunks — safe because the
+   last band is already staged, leaving the render buffer unused until the
+   flush returns. NULL = staging unavailable, per-band pushes as before. */
+static lv_color_t *frame_stage;
+static int stage_dirty_y1;
+static int stage_dirty_y2;
 static lv_disp_draw_buf_t draw_buf;
 static lv_disp_drv_t disp_drv;
 static lv_indev_t *indev_touchpad;
@@ -230,11 +242,47 @@ const esp_lcd_panel_vendor_init_cmd_t lcd_init_cmd[] = {
 static void my_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p)
 {
   ESP_PanelLcd *lcd = (ESP_PanelLcd *)disp->user_data;
-  const int offsetx1 = area->x1;
-  const int offsetx2 = area->x2;
-  const int offsety1 = area->y1;
-  const int offsety2 = area->y2;
-  lcd->drawBitmap(offsetx1, offsety1, offsetx2 - offsetx1 + 1, offsety2 - offsety1 + 1, (const uint8_t *)color_p);
+
+  if (frame_stage != NULL) {
+    const int w = area->x2 - area->x1 + 1;
+    int y;
+
+    for (y = area->y1; y <= area->y2; y++) {
+      memcpy(&frame_stage[y * SCREEN_RES_HOR + area->x1],
+             &color_p[(y - area->y1) * w], (size_t)w * sizeof(lv_color_t));
+    }
+    if (area->y1 < stage_dirty_y1) stage_dirty_y1 = area->y1;
+    if (area->y2 > stage_dirty_y2) stage_dirty_y2 = area->y2;
+
+    if (!lv_disp_flush_is_last(disp)) {
+      lv_disp_flush_ready(disp);
+      return;
+    }
+
+    /* Last band of the frame: push the dirty row range back-to-back via
+       the internal bounce buffer (synchronous chunks, ~15ms total), then
+       release LVGL. */
+    {
+      const int y1 = stage_dirty_y1;
+      const int y2 = stage_dirty_y2;
+      int cy;
+      stage_dirty_y1 = SCREEN_RES_VER;
+      stage_dirty_y2 = -1;
+      for (cy = y1; cy <= y2; cy += STAGE_BOUNCE_ROWS) {
+        int ch = y2 - cy + 1;
+        if (ch > STAGE_BOUNCE_ROWS) ch = STAGE_BOUNCE_ROWS;
+        memcpy(disp_draw_buf, &frame_stage[cy * SCREEN_RES_HOR],
+               (size_t)ch * SCREEN_RES_HOR * sizeof(lv_color_t));
+        lcd->drawBitmap(0, cy, SCREEN_RES_HOR, ch,
+                        (const uint8_t *)disp_draw_buf, 1000);
+      }
+      lv_disp_flush_ready(disp);
+    }
+    return;
+  }
+
+  lcd->drawBitmap(area->x1, area->y1, area->x2 - area->x1 + 1,
+                  area->y2 - area->y1 + 1, (const uint8_t *)color_p);
 }
 
 IRAM_ATTR bool onRefreshFinishCallback(void *user_data)
@@ -554,9 +602,14 @@ void scr_lvgl_init()
     lcd->mirrorY(true);
     touch->mirrorY(true);
   }
-  size_t lv_cache_rows = 72;
+  size_t lv_cache_rows = STAGE_BOUNCE_ROWS;
 
   disp_draw_buf = (lv_color_t *)heap_caps_malloc(lv_cache_rows * SCREEN_RES_HOR * 2, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+  frame_stage = (lv_color_t *)heap_caps_malloc(
+      SCREEN_RES_VER * SCREEN_RES_HOR * sizeof(lv_color_t),
+      MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  stage_dirty_y1 = SCREEN_RES_VER;
+  stage_dirty_y2 = -1;
   lv_init();
   lv_disp_draw_buf_init(&draw_buf, disp_draw_buf, NULL, SCREEN_RES_HOR * lv_cache_rows);
 

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -34,12 +34,10 @@ static int stage_dirty_y2;
 static lv_disp_draw_buf_t draw_buf;
 static lv_disp_drv_t disp_drv;
 static lv_indev_t *indev_touchpad;
-lv_indev_t *indev_knob;
 static ESP_PanelLcd *lcd = NULL;
 static ESP_PanelTouch *touch = NULL;
 static int32_t ctx_diff;
 static lv_indev_state_t encoder_state;
-int encoder_cont = 0;
 static volatile bool touch_irq_pending = false;
 #define USE_CUSTOM_INIT_CMD 0 // 是否用自定义的初始化代码
 
@@ -292,49 +290,6 @@ IRAM_ATTR bool onRefreshFinishCallback(void *user_data)
   return false;
 }
 
-void setRotation(uint8_t rot)
-{
-  if (rot > 3)
-    return;
-  if (lcd == NULL || touch == NULL)
-    return;
-
-  switch (rot)
-  {
-  case 1: // 顺时针90度
-    lcd->swapXY(true);
-    lcd->mirrorX(true);
-    lcd->mirrorY(false);
-    touch->swapXY(true);
-    touch->mirrorX(true);
-    touch->mirrorY(false);
-    break;
-  case 2:
-    lcd->swapXY(false);
-    lcd->mirrorX(true);
-    lcd->mirrorY(true);
-    touch->swapXY(false);
-    touch->mirrorX(true);
-    touch->mirrorY(true);
-    break;
-  case 3:
-    lcd->swapXY(true);
-    lcd->mirrorX(false);
-    lcd->mirrorY(true);
-    touch->swapXY(true);
-    touch->mirrorX(false);
-    touch->mirrorY(true);
-    break;
-  default:
-    lcd->swapXY(false);
-    lcd->mirrorX(false);
-    lcd->mirrorY(false);
-    touch->swapXY(false);
-    touch->mirrorX(false);
-    touch->mirrorY(false);
-    break;
-  }
-}
 
 void scr_display_on(void)
 {
@@ -342,7 +297,6 @@ void scr_display_on(void)
 }
 
 static bool tp_tracking = false;
-static bool tp_swiped = false;
 static lv_point_t tp_start = {0, 0};
 static lv_point_t tp_last = {0, 0};
 static uint32_t tp_start_tick = 0;
@@ -360,7 +314,6 @@ static bool touch_point_valid(int x, int y)
 static void touch_reset_state(void)
 {
   tp_tracking = false;
-  tp_swiped = false;
   tp_start.x = 0;
   tp_start.y = 0;
   tp_last.x = 0;
@@ -404,8 +357,6 @@ static bool check_swipe(int cur_x, int cur_y)
   }
   lv_indev_reset(lv_indev_get_act(), NULL);
   return true;
-
-  return false;
 }
 
 static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
@@ -432,29 +383,25 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
     if (was_dimmed) {
       touch_reset_state();
     }
-    if (tp_swiped) {
-      data->state = LV_INDEV_STATE_RELEASED;
+    data->point.x = point.x;
+    data->point.y = point.y;
+    data->state = LV_INDEV_STATE_PRESSED;
+    if (!tp_tracking) {
+      tp_start.x = point.x;
+      tp_start.y = point.y;
+      tp_last = tp_start;
+      tp_start_tick = lv_tick_get();
+      tp_tracking = true;
     } else {
-      data->point.x = point.x;
-      data->point.y = point.y;
-      data->state = LV_INDEV_STATE_PRESSED;
-      if (!tp_tracking) {
-        tp_start.x = point.x;
-        tp_start.y = point.y;
-        tp_last = tp_start;
-        tp_start_tick = lv_tick_get();
-        tp_tracking = true;
-      } else {
-        tp_last.x = point.x;
-        tp_last.y = point.y;
-        knob_swipe_hint_update(tp_start.x, tp_start.y, point.x, point.y);
-      }
+      tp_last.x = point.x;
+      tp_last.y = point.y;
+      knob_swipe_hint_update(tp_start.x, tp_start.y, point.x, point.y);
     }
   }
   else
   {
-    if (tp_tracking && !tp_swiped && touch_point_valid(tp_last.x, tp_last.y)) {
-      tp_swiped = check_swipe(tp_last.x, tp_last.y);
+    if (tp_tracking && touch_point_valid(tp_last.x, tp_last.y)) {
+      check_swipe(tp_last.x, tp_last.y);
     }
     touch_reset_state();
     data->state = LV_INDEV_STATE_RELEASED;
@@ -641,7 +588,7 @@ void scr_lvgl_init()
   iot_knob_register_cb(s_knob, KNOB_LEFT, _knob_left_cb, &ctx_diff);
   iot_knob_register_cb(s_knob, KNOB_RIGHT, _knob_right_cb, &ctx_diff);
   
-  indev_knob = indev_knob_init(&s_knob);
+  indev_knob_init(&s_knob);
 }
 
 #endif

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -36,8 +36,6 @@ static lv_disp_drv_t disp_drv;
 static lv_indev_t *indev_touchpad;
 static ESP_PanelLcd *lcd = NULL;
 static ESP_PanelTouch *touch = NULL;
-static int32_t ctx_diff;
-static lv_indev_state_t encoder_state;
 static volatile bool touch_irq_pending = false;
 #define USE_CUSTOM_INIT_CMD 0 // 是否用自定义的初始化代码
 
@@ -419,67 +417,19 @@ static void touchpad_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
   }
 }
 
-static int32_t _knob_calculate_diff(knob_handle_t knob, knob_event_t event)
-{
-   static int32_t last_v = 0;
-
-    int32_t diff = 0;
-    int32_t invd = iot_knob_get_count_value(knob);
-    knob_change(event,invd);       
-    if (last_v ^ invd) {
-
-        diff = (int32_t)((uint32_t)invd - (uint32_t)last_v);
-        diff += (event == KNOB_RIGHT && invd < last_v) ? 16 :
-                (event == KNOB_LEFT && invd > last_v) ? -16 : 0;
-        last_v = invd;
-    }
-
-    return diff;
-}
-
+/* Each detent enqueues one event onto the SPSC ring in knob.c; the main
+   loop drains it via knob_process_pending(). LVGL's encoder indev is not
+   used (no lv_group is attached), so there is no ctx_diff/knob_read path. */
 static void _knob_right_cb(void *arg, void *data)
 {
-    knob_handle_t knob = (knob_handle_t)arg;
-    // int32_t ctx = (int32_t )data;
-    int32_t diff = _knob_calculate_diff(knob,KNOB_RIGHT);
-    
-    
-    ctx_diff = (ctx_diff < 0)? diff : ctx_diff + diff;
-
+    (void)arg; (void)data;
+    knob_change(KNOB_RIGHT);
 }
 
 static void _knob_left_cb(void *arg, void *data)
 {
-    knob_handle_t knob = (knob_handle_t)arg;
-    // int32_t ctx = (int32_t )data; 
-    int32_t diff = _knob_calculate_diff(knob,KNOB_LEFT);
-    
-    ctx_diff = (ctx_diff > 0) ? ctx_diff : ctx_diff + diff;
-
-}
-
-
-
-static void knob_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data)
-{
-  knob_handle_t *knob = (knob_handle_t *)indev_drv -> user_data;
-  data->enc_diff = ctx_diff;
-  // data->state = (ctx_diff == 0) ? LV_INDEV_STATE_REL : LV_INDEV_STATE_PR;
-  data->state = LV_INDEV_STATE_REL;
-  // printf("ctx_diff = %d\r\n",ctx_diff);
-  ctx_diff = 0;
-  
-}
-
-static lv_indev_t *indev_knob_init(knob_handle_t *knob)
-{
-  assert(knob);
-  static lv_indev_drv_t indev_drv_knob;
-  lv_indev_drv_init(&indev_drv_knob);
-  indev_drv_knob.type = LV_INDEV_TYPE_ENCODER;
-  indev_drv_knob.read_cb = knob_read;
-  indev_drv_knob.user_data = (void *)knob;
-  return lv_indev_drv_register(&indev_drv_knob);
+    (void)arg; (void)data;
+    knob_change(KNOB_LEFT);
 }
 
 static lv_indev_t *indev_init(ESP_PanelTouch *tp)
@@ -602,10 +552,8 @@ void scr_lvgl_init()
         Serial.printf("knob create failed\n");
         return;
     }
-  iot_knob_register_cb(s_knob, KNOB_LEFT, _knob_left_cb, &ctx_diff);
-  iot_knob_register_cb(s_knob, KNOB_RIGHT, _knob_right_cb, &ctx_diff);
-  
-  indev_knob_init(&s_knob);
+  iot_knob_register_cb(s_knob, KNOB_LEFT, _knob_left_cb, NULL);
+  iot_knob_register_cb(s_knob, KNOB_RIGHT, _knob_right_cb, NULL);
 }
 
 #endif

--- a/knobby/src/damage_log.c
+++ b/knobby/src/damage_log.c
@@ -4,7 +4,7 @@
 // ---------- data ----------
 typedef struct {
     uint32_t timestamp_ms;
-    int8_t   player;       // target: -1 = single player, 0-3 = multiplayer index
+    int8_t   player;       // target player index, 0..MAX_GAME_PLAYERS-1
     int8_t   source;       // source for cmd damage or counter type, -1 if N/A
     uint8_t  event_type;   // log_event_type_t
     int16_t  delta;
@@ -130,6 +130,7 @@ static void format_log_line(damage_log_entry_t *entry, char *buf, size_t buf_sz)
     int abs_delta = entry->delta > 0 ? entry->delta : -entry->delta;
     char time_str[16];
 
+    buf[0] = '\0';  /* ensure a defined string if no branch below matches */
     format_elapsed(elapsed_s, time_str, sizeof(time_str));
 
     if (entry->event_type == LOG_EVT_CMD_DAMAGE && entry->source >= 0 &&
@@ -140,7 +141,8 @@ static void format_log_line(damage_log_entry_t *entry, char *buf, size_t buf_sz)
                  player_names[entry->source],
                  abs_delta,
                  player_names[entry->player]);
-    } else if (entry->event_type == LOG_EVT_COUNTER && entry->source >= 0 && entry->player >= 0) {
+    } else if (entry->event_type == LOG_EVT_COUNTER && entry->source >= 0 &&
+               entry->player >= 0 && entry->player < MAX_GAME_PLAYERS) {
         const counter_definition_t *definition = get_counter_definition((counter_type_t)entry->source);
         const char *action = entry->delta > 0 ? "increased" : "decreased";
         const char *counter_name = (definition != NULL) ? definition->display_name : "Counter";
@@ -175,9 +177,12 @@ static void update_selection_highlight(void)
         }
     }
 
-    /* Scroll selected item into view */
+    /* Scroll selected item into view. Force the flex layout first: rows
+       recreated this pass still have {0,0,0,0} coords until LVGL lays them
+       out, which would scroll to the wrong place. */
     if (sel_child >= 0 && sel_child < (int)child_count) {
         lv_obj_t *sel = lv_obj_get_child(damage_log_container, sel_child);
+        lv_obj_update_layout(damage_log_container);
         lv_coord_t sel_y = lv_obj_get_y(sel);
         lv_coord_t sel_h = lv_obj_get_height(sel);
         lv_coord_t cont_h = lv_obj_get_height(damage_log_container);

--- a/knobby/src/damage_log.c
+++ b/knobby/src/damage_log.c
@@ -15,10 +15,18 @@ static int damage_log_count = 0;
 static int damage_log_head = 0;
 
 // ---------- screen ----------
+/* Labels are rendered one page at a time: a full 256-entry ring as one
+   widget per entry would eat most of the 128KB LVGL heap and hard-freeze
+   the device on alloc failure (LV_ASSERT_HANDLER). */
+#define LOG_PAGE_SIZE 32
+
 lv_obj_t *screen_damage_log = NULL;
 static lv_obj_t *damage_log_container = NULL;
 static lv_obj_t *delete_btn = NULL;
-static int damage_log_selected = -1;  // index into visible list (0 = newest)
+static lv_obj_t *page_label = NULL;
+static int damage_log_selected = -1;  // index into the log, 0 = newest
+static int damage_log_page = 0;       // rendered page, derived from selection
+static lv_style_t log_label_style;    // shared by all entry labels
 
 // ---------- log operations ----------
 void damage_log_add(int player, int delta, uint8_t event_type, int source)
@@ -48,7 +56,11 @@ void damage_log_select_next(void)
     if (damage_log_selected < damage_log_count - 1) {
         damage_log_selected++;
     }
-    update_selection_highlight();
+    if (damage_log_selected / LOG_PAGE_SIZE != damage_log_page) {
+        refresh_damage_log_ui();
+    } else {
+        update_selection_highlight();
+    }
 }
 
 void damage_log_select_prev(void)
@@ -57,7 +69,11 @@ void damage_log_select_prev(void)
     if (damage_log_selected > 0) {
         damage_log_selected--;
     }
-    update_selection_highlight();
+    if (damage_log_selected / LOG_PAGE_SIZE != damage_log_page) {
+        refresh_damage_log_ui();
+    } else {
+        update_selection_highlight();
+    }
 }
 
 void damage_log_undo_selected(void)
@@ -144,13 +160,14 @@ static void format_log_line(damage_log_entry_t *entry, char *buf, size_t buf_sz)
 static void update_selection_highlight(void)
 {
     int i;
+    int first = damage_log_page * LOG_PAGE_SIZE;
+    int sel_child = damage_log_selected - first;
     uint32_t child_count = lv_obj_get_child_cnt(damage_log_container);
 
-    for (i = 0; i < (int)child_count && i < damage_log_count; i++) {
-        int idx = (damage_log_head - 1 - i + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
+    for (i = 0; i < (int)child_count && first + i < damage_log_count; i++) {
         lv_obj_t *lbl = lv_obj_get_child(damage_log_container, i);
 
-        if (i == damage_log_selected) {
+        if (i == sel_child) {
             lv_obj_set_style_bg_color(lbl, lv_color_hex(0x333333), 0);
             lv_obj_set_style_bg_opa(lbl, LV_OPA_COVER, 0);
         } else {
@@ -159,8 +176,8 @@ static void update_selection_highlight(void)
     }
 
     /* Scroll selected item into view */
-    if (damage_log_selected >= 0 && damage_log_selected < (int)child_count) {
-        lv_obj_t *sel = lv_obj_get_child(damage_log_container, damage_log_selected);
+    if (sel_child >= 0 && sel_child < (int)child_count) {
+        lv_obj_t *sel = lv_obj_get_child(damage_log_container, sel_child);
         lv_coord_t sel_y = lv_obj_get_y(sel);
         lv_coord_t sel_h = lv_obj_get_height(sel);
         lv_coord_t cont_h = lv_obj_get_height(damage_log_container);
@@ -185,7 +202,7 @@ static void update_selection_highlight(void)
 
 static void refresh_damage_log_ui(void)
 {
-    int i, idx;
+    int i, idx, first, last;
     char buf[80];
 
     lv_obj_clean(damage_log_container);
@@ -196,11 +213,22 @@ static void refresh_damage_log_ui(void)
         lv_obj_set_style_text_color(lbl, lv_color_hex(0x7A7A7A), 0);
         lv_obj_set_style_text_font(lbl, &lv_font_montserrat_16, 0);
         damage_log_selected = -1;
+        damage_log_page = 0;
+        if (page_label != NULL) lv_obj_add_flag(page_label, LV_OBJ_FLAG_HIDDEN);
         update_selection_highlight();
         return;
     }
 
-    for (i = 0; i < damage_log_count; i++) {
+    if (damage_log_selected >= damage_log_count) {
+        damage_log_selected = damage_log_count - 1;
+    }
+    damage_log_page = (damage_log_selected > 0) ? damage_log_selected / LOG_PAGE_SIZE : 0;
+
+    first = damage_log_page * LOG_PAGE_SIZE;
+    last = first + LOG_PAGE_SIZE;
+    if (last > damage_log_count) last = damage_log_count;
+
+    for (i = first; i < last; i++) {
         idx = (damage_log_head - 1 - i + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
 
         format_log_line(&damage_log[idx], buf, sizeof(buf));
@@ -208,11 +236,7 @@ static void refresh_damage_log_ui(void)
         lv_obj_t *lbl = lv_label_create(damage_log_container);
         lv_label_set_text(lbl, buf);
         lv_obj_set_width(lbl, 280);
-        lv_obj_set_style_pad_left(lbl, 4, 0);
-        lv_obj_set_style_pad_right(lbl, 4, 0);
-        lv_obj_set_style_pad_top(lbl, 2, 0);
-        lv_obj_set_style_pad_bottom(lbl, 2, 0);
-        lv_obj_set_style_radius(lbl, 4, 0);
+        lv_obj_add_style(lbl, &log_label_style, 0);
         if (damage_log[idx].event_type == LOG_EVT_COUNTER) {
             const counter_definition_t *definition = get_counter_definition((counter_type_t)damage_log[idx].source);
             lv_obj_set_style_text_color(lbl,
@@ -221,11 +245,17 @@ static void refresh_damage_log_ui(void)
             lv_obj_set_style_text_color(lbl,
                 damage_log[idx].delta > 0 ? lv_color_hex(0x4CAF50) : lv_color_hex(0xFF5252), 0);
         }
-        lv_obj_set_style_text_font(lbl, &lv_font_montserrat_14, 0);
     }
 
-    if (damage_log_selected >= damage_log_count) {
-        damage_log_selected = damage_log_count - 1;
+    if (page_label != NULL) {
+        if (damage_log_count > LOG_PAGE_SIZE) {
+            char page_buf[24];
+            snprintf(page_buf, sizeof(page_buf), "%d-%d of %d", first + 1, last, damage_log_count);
+            lv_label_set_text(page_label, page_buf);
+            lv_obj_clear_flag(page_label, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(page_label, LV_OBJ_FLAG_HIDDEN);
+        }
     }
 
     lv_obj_scroll_to_y(damage_log_container, 0, LV_ANIM_OFF);
@@ -268,6 +298,21 @@ void build_damage_log_screen(void)
     lv_obj_set_style_text_color(title, lv_color_white(), 0);
     lv_obj_set_style_text_font(title, &lv_font_montserrat_22, 0);
     lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 24);
+
+    page_label = lv_label_create(screen_damage_log);
+    lv_label_set_text(page_label, "");
+    lv_obj_set_style_text_color(page_label, lv_color_hex(0x7A7A7A), 0);
+    lv_obj_set_style_text_font(page_label, &lv_font_montserrat_14, 0);
+    lv_obj_align(page_label, LV_ALIGN_TOP_MID, 0, 54);
+    lv_obj_add_flag(page_label, LV_OBJ_FLAG_HIDDEN);
+
+    lv_style_init(&log_label_style);
+    lv_style_set_pad_left(&log_label_style, 4);
+    lv_style_set_pad_right(&log_label_style, 4);
+    lv_style_set_pad_top(&log_label_style, 2);
+    lv_style_set_pad_bottom(&log_label_style, 2);
+    lv_style_set_radius(&log_label_style, 4);
+    lv_style_set_text_font(&log_label_style, &lv_font_montserrat_14);
 
     damage_log_container = lv_obj_create(screen_damage_log);
     lv_obj_remove_style_all(damage_log_container);

--- a/knobby/src/damage_log.c
+++ b/knobby/src/damage_log.c
@@ -47,6 +47,27 @@ void damage_log_reset(void)
     damage_log_head = 0;
 }
 
+/* Remove the newest entry matching player + event_type (used by elimination
+   undo so the eliminating event can't also be undone from the log). */
+void damage_log_remove_last_for(int player, uint8_t event_type)
+{
+    int i, j;
+    for (i = 0; i < damage_log_count; i++) {
+        int idx = (damage_log_head - 1 - i + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
+        if (damage_log[idx].player == player &&
+            damage_log[idx].event_type == event_type) {
+            for (j = i; j > 0; j--) {
+                int dst = (damage_log_head - 1 - j + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
+                int src = (damage_log_head - j + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
+                damage_log[dst] = damage_log[src];
+            }
+            damage_log_head = (damage_log_head - 1 + DAMAGE_LOG_MAX) % DAMAGE_LOG_MAX;
+            damage_log_count--;
+            return;
+        }
+    }
+}
+
 static void update_selection_highlight(void);
 static void refresh_damage_log_ui(void);
 

--- a/knobby/src/damage_log.h
+++ b/knobby/src/damage_log.h
@@ -8,7 +8,6 @@
 typedef enum {
     LOG_EVT_LIFE = 0,
     LOG_EVT_CMD_DAMAGE,
-    LOG_EVT_POISON,
     LOG_EVT_COUNTER,
 } log_event_type_t;
 

--- a/knobby/src/damage_log.h
+++ b/knobby/src/damage_log.h
@@ -15,6 +15,7 @@ extern lv_obj_t *screen_damage_log;
 
 void damage_log_add(int player, int delta, uint8_t event_type, int source);
 void damage_log_reset(void);
+void damage_log_remove_last_for(int player, uint8_t event_type);
 void damage_log_select_next(void);
 void damage_log_select_prev(void);
 void damage_log_undo_selected(void);

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -426,6 +426,22 @@ void selection_set_single(int player)
     player_selected[player] = true;
 }
 
+/* The single entry point for committing a life change as a game event:
+   log + clamp + elimination-undo action + elimination check. Any path
+   that applies life deltas (knob commit, All Damage) must use this so
+   the elimination machinery can't be bypassed. */
+void apply_life_delta(int player, int delta)
+{
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
+    if (player_eliminated[player]) return;
+    damage_log_add(player, delta, LOG_EVT_LIFE, -1);
+    player_life[player] = clamp_life(player_life[player] + delta);
+    if (player_life[player] <= 0) {
+        set_player_elimination_action(player, LOG_EVT_LIFE, -1, delta);
+    }
+    check_player_elimination(player);
+}
+
 // ---------- life preview ----------
 void life_preview_commit_cb(lv_timer_t *timer)
 {
@@ -444,13 +460,8 @@ void life_preview_commit_cb(lv_timer_t *timer)
     }
 
     for (i = 0; i < track && i < MAX_DISPLAY_PLAYERS; i++) {
-        if (!player_selected[i] || player_eliminated[i]) continue;
-        damage_log_add(i, pending_life_delta, LOG_EVT_LIFE, -1);
-        player_life[i] = clamp_life(player_life[i] + pending_life_delta);
-        if (player_life[i] <= 0) {
-            set_player_elimination_action(i, LOG_EVT_LIFE, -1, pending_life_delta);
-        }
-        check_player_elimination(i);
+        if (!player_selected[i]) continue;
+        apply_life_delta(i, pending_life_delta);
     }
     pending_life_delta = 0;
     life_preview_active = false;

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -106,7 +106,10 @@ void check_player_elimination(int player)
     bool was_eliminated = player_eliminated[player];
     bool now_eliminated = false;
 
-    if (nvs_get_auto_eliminate()) {
+    /* Elimination is a multiplayer concept: with a single tracked player
+       there is no eliminated-menu route in the 1p UI, so eliminating
+       player 0 would brick the counter until reset. */
+    if (nvs_get_auto_eliminate() && nvs_get_players_to_track() > 1) {
         if (player_life[player] <= 0) {
             now_eliminated = true;
         } else {
@@ -142,6 +145,8 @@ void manual_eliminate_player(int player)
 {
     if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     if (player_eliminated[player]) return;
+    /* Same solo-mode exemption as check_player_elimination. */
+    if (nvs_get_players_to_track() <= 1) return;
     player_eliminated[player] = true;
     clear_player_elimination_action(player);
     if (player_selected[player]) {

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -692,6 +692,10 @@ static void player_select_anim_cb(lv_timer_t *timer)
     // Move to next player (clockwise logic mapping to bottom/left/top/right)
     roulette_idx = (roulette_idx + 1) % track;
     selection_set_single(roulette_idx);
+    /* Restart the deselect-timeout countdown like any selection change,
+       so a timer left running from before the reset can't fire mid-spin
+       and blank the selection for a tick. */
+    select_kick_timer();
     refresh_player_ui();
 
     player_select_anim_steps--;
@@ -727,6 +731,7 @@ void start_player_selection_animation(void)
 
     roulette_idx = 0;
     selection_set_single(0);
+    select_kick_timer();
 
     lv_timer_set_period(player_select_anim_timer, player_select_anim_period);
     lv_timer_resume(player_select_anim_timer);

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -652,6 +652,7 @@ void start_player_selection_animation(void)
     int random_stops;
 
     if (track <= 1) return;
+    if (!nvs_get_random_first()) return;
 
     if (player_select_anim_timer == NULL) {
         player_select_anim_timer = lv_timer_create(player_select_anim_cb, 50, NULL);

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -36,6 +36,10 @@ int player_counters[MAX_DISPLAY_PLAYERS][COUNTER_TYPE_COUNT] = {{0}};
 counter_type_t counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
 int counter_edit_value = 0;
 bool player_eliminated[MAX_DISPLAY_PLAYERS] = {false};
+/* Conceded players (manual elimination) tracked apart from auto-elimination,
+   so an undo that recomputes auto conditions can't revive someone who
+   manually conceded while still above 0 life. */
+static bool player_manually_eliminated[MAX_DISPLAY_PLAYERS] = {false};
 
 typedef struct {
     bool valid;
@@ -98,6 +102,11 @@ void undo_elimination_action(int player)
     } else if (action.event_type == LOG_EVT_COUNTER) {
         undo_counter_change(player, action.source, action.delta);
     }
+
+    /* Drop the log entry that caused the elimination so the same event can't
+       be undone a second time from the Event Log. The eliminating event is
+       the newest one for this player (eliminated players accrue no more). */
+    damage_log_remove_last_for(player, action.event_type);
 }
 
 void check_player_elimination(int player)
@@ -125,6 +134,10 @@ void check_player_elimination(int player)
         }
     }
 
+    if (player_manually_eliminated[player]) {
+        now_eliminated = true;
+    }
+
     player_eliminated[player] = now_eliminated;
     if (!now_eliminated) {
         clear_player_elimination_action(player);
@@ -148,6 +161,7 @@ void manual_eliminate_player(int player)
     /* Same solo-mode exemption as check_player_elimination. */
     if (nvs_get_players_to_track() <= 1) return;
     player_eliminated[player] = true;
+    player_manually_eliminated[player] = true;
     clear_player_elimination_action(player);
     if (player_selected[player]) {
         player_selected[player] = false;
@@ -161,6 +175,7 @@ void manual_uneliminate_player(int player)
     if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     if (!player_eliminated[player]) return;
     player_eliminated[player] = false;
+    player_manually_eliminated[player] = false;
     clear_player_elimination_action(player);
     refresh_player_ui();
 }
@@ -643,6 +658,8 @@ void knob_life_reset(void)
     if (active_enemy_count < 0) active_enemy_count = 0;
     if (active_enemy_count > MAX_ENEMY_COUNT) active_enemy_count = MAX_ENEMY_COUNT;
 
+    damage_log_reset();
+
     pending_life_delta = 0;
     selection_clear();
     life_preview_active = false;
@@ -661,6 +678,8 @@ void knob_life_reset(void)
     memset(cmd_damage_totals, 0, sizeof(cmd_damage_totals));
     memset(player_counters, 0, sizeof(player_counters));
     memset(player_eliminated, 0, sizeof(player_eliminated));
+    memset(player_manually_eliminated, 0, sizeof(player_manually_eliminated));
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) clear_player_elimination_action(i);
     all_damage_value = 0;
     counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
     counter_edit_value = 0;

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -542,6 +542,10 @@ void change_player_life(int delta)
     int min_down = LIFE_MIN;
     int i;
 
+    /* The roulette walks the selection every tick, so a delta dialed
+       mid-spin would land on whichever player the wheel stops at. */
+    if (player_selection_animation_active()) return;
+
     if (selection_count() == 0) return;
 
     select_kick_timer();
@@ -760,4 +764,9 @@ void stop_player_selection_animation(void)
         lv_timer_del(player_select_anim_timer);
         player_select_anim_timer = NULL;
     }
+}
+
+bool player_selection_animation_active(void)
+{
+    return player_select_anim_timer != NULL && player_select_anim_steps > 0;
 }

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -509,6 +509,7 @@ void damage_apply(void)
     int source;
 
     if (selected_enemy < 0 || selected_enemy >= active_enemy_count) return;
+    if (cmd_damage_target < 0 || cmd_damage_target >= MAX_DISPLAY_PLAYERS) return;
 
     delta = enemies[selected_enemy].damage - damage_start_value;
     if (delta == 0) return;

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -21,7 +21,7 @@ int selected_enemy = -1;
 int dice_result = 0;
 
 int player_life[MAX_DISPLAY_PLAYERS] = {40, 40, 40, 40};
-int selected_player = -1;
+bool player_selected[MAX_DISPLAY_PLAYERS] = {false};
 char player_names[MAX_GAME_PLAYERS][16] = {
     "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"
 };
@@ -31,7 +31,6 @@ int all_damage_value = 0;
 int cmd_damage_target = -1;
 static int damage_start_value = 0;
 int pending_life_delta = 0;
-int preview_player = -1;
 bool life_preview_active = false;
 int player_counters[MAX_DISPLAY_PLAYERS][COUNTER_TYPE_COUNT] = {{0}};
 counter_type_t counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
@@ -126,6 +125,12 @@ void check_player_elimination(int player)
     player_eliminated[player] = now_eliminated;
     if (!now_eliminated) {
         clear_player_elimination_action(player);
+    } else if (player_selected[player]) {
+        /* An eliminated player is no longer a life-change target: drop it
+           from the selection so the knob doesn't preview onto a dead panel
+           that can't be tapped to deselect. */
+        player_selected[player] = false;
+        select_kick_timer();
     }
 
     if (was_eliminated != now_eliminated) {
@@ -139,6 +144,10 @@ void manual_eliminate_player(int player)
     if (player_eliminated[player]) return;
     player_eliminated[player] = true;
     clear_player_elimination_action(player);
+    if (player_selected[player]) {
+        player_selected[player] = false;
+        select_kick_timer();
+    }
     refresh_player_ui();
 }
 
@@ -380,33 +389,80 @@ int apply_counter_edit(void)
     return change_delta;
 }
 
+// ---------- player selection set ----------
+int selection_count(void)
+{
+    int i, n = 0;
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++)
+        if (player_selected[i]) n++;
+    return n;
+}
+
+bool is_player_selected(int player)
+{
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return false;
+    return player_selected[player];
+}
+
+void selection_clear(void)
+{
+    int i;
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++)
+        player_selected[i] = false;
+}
+
+void selection_toggle(int player)
+{
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
+    if (player_eliminated[player]) return;
+    player_selected[player] = !player_selected[player];
+}
+
+void selection_set_single(int player)
+{
+    selection_clear();
+    if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
+    if (player_eliminated[player]) return;
+    player_selected[player] = true;
+}
+
 // ---------- life preview ----------
 void life_preview_commit_cb(lv_timer_t *timer)
 {
+    int track = nvs_get_players_to_track();
+    int i;
+
     (void)timer;
 
-    if (!life_preview_active ||
-        preview_player < 0 ||
-        preview_player >= nvs_get_players_to_track()) {
+    if (!life_preview_active || selection_count() == 0) {
+        pending_life_delta = 0;
+        life_preview_active = false;
         if (life_preview_timer != NULL) {
             lv_timer_pause(life_preview_timer);
         }
         return;
     }
 
-    damage_log_add(preview_player, pending_life_delta, LOG_EVT_LIFE, -1);
-    player_life[preview_player] = clamp_life(
-        player_life[preview_player] + pending_life_delta
-    );
-    if (player_life[preview_player] <= 0) {
-        set_player_elimination_action(preview_player, LOG_EVT_LIFE, -1, pending_life_delta);
+    for (i = 0; i < track && i < MAX_DISPLAY_PLAYERS; i++) {
+        if (!player_selected[i] || player_eliminated[i]) continue;
+        damage_log_add(i, pending_life_delta, LOG_EVT_LIFE, -1);
+        player_life[i] = clamp_life(player_life[i] + pending_life_delta);
+        if (player_life[i] <= 0) {
+            set_player_elimination_action(i, LOG_EVT_LIFE, -1, pending_life_delta);
+        }
+        check_player_elimination(i);
     }
-    check_player_elimination(preview_player);
     pending_life_delta = 0;
-    preview_player = -1;
     life_preview_active = false;
     if (life_preview_timer != NULL) {
         lv_timer_pause(life_preview_timer);
+    }
+    /* Applying a life change ends the operation: in multi-select mode clear
+       the selection so the next tap starts a fresh selection. Otherwise
+       sequential per-player damage keeps stacking players into the set. */
+    if (nvs_get_multi_select()) {
+        selection_clear();
+        select_kick_timer();
     }
     refresh_player_ui();
 }
@@ -461,34 +517,37 @@ void damage_cancel(void)
 
 void change_player_life(int delta)
 {
-    int preview_base;
+    /* The shared delta applies to every currently-selected player. Clamp it
+       to the headroom of the selected set so the previewed totals always
+       equal what the commit will store and overshoot detents at the life
+       cap are absorbed instead of accumulating. */
     int track = nvs_get_players_to_track();
+    int max_up = LIFE_MAX;
+    int min_down = LIFE_MIN;
+    int i;
 
-    if (selected_player < 0 || selected_player >= track) return;
-    if (player_eliminated[selected_player]) return;
+    if (selection_count() == 0) return;
 
     select_kick_timer();
 
-    if (life_preview_active &&
-        preview_player != selected_player) {
-        life_preview_commit_cb(NULL);
+    for (i = 0; i < track && i < MAX_DISPLAY_PLAYERS; i++) {
+        if (!player_selected[i] || player_eliminated[i]) continue;
+        if (LIFE_MAX - player_life[i] < max_up) max_up = LIFE_MAX - player_life[i];
+        if (LIFE_MIN - player_life[i] > min_down) min_down = LIFE_MIN - player_life[i];
     }
 
-    preview_player = selected_player;
-    preview_base = player_life[preview_player];
     pending_life_delta += delta;
-    pending_life_delta = clamp_life(preview_base + pending_life_delta) - preview_base;
+    if (pending_life_delta > max_up) pending_life_delta = max_up;
+    if (pending_life_delta < min_down) pending_life_delta = min_down;
     life_preview_active = (pending_life_delta != 0);
 
     if (life_preview_timer != NULL) {
-        lv_timer_reset(life_preview_timer);
-    }
-
-    if (!life_preview_active && life_preview_timer != NULL) {
-        lv_timer_pause(life_preview_timer);
-        preview_player = -1;
-    } else if (life_preview_timer != NULL) {
-        lv_timer_resume(life_preview_timer);
+        if (life_preview_active) {
+            lv_timer_reset(life_preview_timer);
+            lv_timer_resume(life_preview_timer);
+        } else {
+            lv_timer_pause(life_preview_timer);
+        }
     }
 
     refresh_player_ui();
@@ -564,7 +623,7 @@ void knob_life_reset(void)
     if (active_enemy_count > MAX_ENEMY_COUNT) active_enemy_count = MAX_ENEMY_COUNT;
 
     pending_life_delta = 0;
-    preview_player = -1;
+    selection_clear();
     life_preview_active = false;
     selected_enemy = -1;
     dice_result = 0;
@@ -576,7 +635,6 @@ void knob_life_reset(void)
     for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) {
         player_life[i] = starting_life;
     }
-    selected_player = -1;
     menu_player = 0;
     cmd_damage_target = -1;
     memset(cmd_damage_totals, 0, sizeof(cmd_damage_totals));
@@ -619,6 +677,7 @@ void knob_life_init(void)
 static lv_timer_t *player_select_anim_timer = NULL;
 static int player_select_anim_steps = 0;
 static int player_select_anim_period = 0;
+static int roulette_idx = 0;
 
 static void player_select_anim_cb(lv_timer_t *timer)
 {
@@ -631,7 +690,8 @@ static void player_select_anim_cb(lv_timer_t *timer)
     }
 
     // Move to next player (clockwise logic mapping to bottom/left/top/right)
-    selected_player = (selected_player + 1) % track;
+    roulette_idx = (roulette_idx + 1) % track;
+    selection_set_single(roulette_idx);
     refresh_player_ui();
 
     player_select_anim_steps--;
@@ -665,8 +725,18 @@ void start_player_selection_animation(void)
     player_select_anim_steps = random_stops;
     player_select_anim_period = 40; // start fast
 
-    if (selected_player < 0) selected_player = 0;
+    roulette_idx = 0;
+    selection_set_single(0);
 
     lv_timer_set_period(player_select_anim_timer, player_select_anim_period);
     lv_timer_resume(player_select_anim_timer);
+}
+
+void stop_player_selection_animation(void)
+{
+    player_select_anim_steps = 0;
+    if (player_select_anim_timer != NULL) {
+        lv_timer_del(player_select_anim_timer);
+        player_select_anim_timer = NULL;
+    }
 }

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -69,6 +69,7 @@ const counter_definition_t *get_counter_definition(counter_type_t type);
 bool counter_type_is_enabled(counter_type_t type);
 void start_player_selection_animation(void);
 void stop_player_selection_animation(void);
+bool player_selection_animation_active(void);
 
 bool elimination_action_available(int player);
 void undo_elimination_action(int player);

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -25,14 +25,13 @@ extern int active_enemy_count;
 extern enemy_state_t enemies[MAX_ENEMY_COUNT];
 extern int selected_enemy;
 extern int player_life[MAX_DISPLAY_PLAYERS];
-extern int selected_player;
+extern bool player_selected[MAX_DISPLAY_PLAYERS];
 extern char player_names[MAX_GAME_PLAYERS][16];
 extern int menu_player;
 extern int cmd_damage_totals[MAX_GAME_PLAYERS][MAX_DISPLAY_PLAYERS];
 extern int cmd_damage_target;
 extern int all_damage_value;
 extern int pending_life_delta;
-extern int preview_player;
 extern bool life_preview_active;
 extern int dice_result;
 extern int player_counters[MAX_DISPLAY_PLAYERS][COUNTER_TYPE_COUNT];
@@ -49,6 +48,13 @@ void damage_apply(void);
 void damage_cancel(void);
 void change_player_life(int delta);
 void change_all_damage(int delta);
+
+// ---------- player selection set ----------
+int selection_count(void);
+bool is_player_selected(int player);
+void selection_clear(void);
+void selection_toggle(int player);
+void selection_set_single(int player);
 void undo_life_change(int player, int delta);
 void undo_cmd_damage(int source, int target, int delta);
 void undo_counter_change(int player, int counter_type, int delta);
@@ -61,6 +67,7 @@ int get_counter_value(int player, counter_type_t type);
 const counter_definition_t *get_counter_definition(counter_type_t type);
 bool counter_type_is_enabled(counter_type_t type);
 void start_player_selection_animation(void);
+void stop_player_selection_animation(void);
 
 bool elimination_action_available(int player);
 void undo_elimination_action(int player);

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -48,6 +48,7 @@ void damage_apply(void);
 void damage_cancel(void);
 void change_player_life(int delta);
 void change_all_damage(int delta);
+void apply_life_delta(int player, int delta);
 
 // ---------- player selection set ----------
 int selection_count(void);

--- a/knobby/src/game_mode.c
+++ b/knobby/src/game_mode.c
@@ -63,7 +63,7 @@ void open_game_mode_menu(void)
 void change_custom_life(int delta)
 {
     temp_life_total += delta;
-    if (temp_life_total < 0) temp_life_total = 0;
+    if (temp_life_total < 1) temp_life_total = 1;
     if (temp_life_total > LIFE_MAX) temp_life_total = LIFE_MAX;
     refresh_custom_life_ui();
 }

--- a/knobby/src/hw.c
+++ b/knobby/src/hw.c
@@ -17,7 +17,6 @@
 
 // ---------- state ----------
 int brightness_percent = DEFAULT_BRIGHTNESS_PERCENT;
-int auto_dim_setting = AUTO_DIM_OFF;
 bool dimmed = false;
 float battery_voltage = 0.0f;
 int battery_percent = -1;
@@ -231,8 +230,9 @@ static void auto_dim_timer_cb(lv_timer_t *timer)
     // dim state.  update_battery_measurement() has its own 60s throttle.
     update_battery_measurement(false);
 
-    if (auto_dim_setting == AUTO_DIM_OFF || dimmed) return;
-    uint32_t timeout = auto_dim_ms[auto_dim_setting];
+    int dim_setting = nvs_get_auto_dim();
+    if (dim_setting == AUTO_DIM_OFF || dimmed) return;
+    uint32_t timeout = auto_dim_ms[dim_setting];
     if (lv_tick_elaps(last_activity_tick) >= timeout) {
         dimmed = true;
         uint32_t duty = (uint32_t)((AUTO_DIM_BRIGHTNESS * BACKLIGHT_DUTY_MAX) / 100);
@@ -250,7 +250,6 @@ void knob_hw_init(void)
     knob_nvs_init();
     brightness_init();
     brightness_percent = nvs_get_brightness();
-    auto_dim_setting = nvs_get_auto_dim();
     last_activity_tick = lv_tick_get();
     auto_dim_timer = lv_timer_create(auto_dim_timer_cb, AUTO_DIM_CHECK_PERIOD_MS, NULL);
     battery_icon_timer = lv_timer_create(battery_icon_timer_cb, BATTERY_BLINK_PERIOD_MS, NULL);

--- a/knobby/src/hw.h
+++ b/knobby/src/hw.h
@@ -9,7 +9,6 @@ extern "C" {
 
 // ---------- state ----------
 extern int brightness_percent;
-extern int auto_dim_setting;
 extern bool dimmed;
 extern float battery_voltage;
 extern int battery_percent;

--- a/knobby/src/rename.c
+++ b/knobby/src/rename.c
@@ -249,9 +249,11 @@ static void update_mru_highlight(void)
         }
     }
 
-    /* Scroll selected into view */
+    /* Scroll selected into view. Force layout first: rows rebuilt this pass
+       have {0,0,0,0} coords until LVGL lays out the flex container. */
     if (mru_selected >= 0 && mru_selected < (int)child_count) {
         lv_obj_t *sel = lv_obj_get_child(mru_list_container, mru_selected);
+        lv_obj_update_layout(mru_list_container);
         lv_coord_t sel_y = lv_obj_get_y(sel);
         lv_coord_t sel_h = lv_obj_get_height(sel);
         lv_coord_t cont_h = lv_obj_get_height(mru_list_container);

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -268,6 +268,21 @@ static const char *random_first_label(int val)
     return val ? "Random\nFirst\nON" : "Random\nFirst\nOFF";
 }
 
+static const char *multi_select_label(int val)
+{
+    return val ? "Multi-\nSelect\nON" : "Multi-\nSelect\nOFF";
+}
+
+static void multi_select_set(int v)
+{
+    nvs_set_multi_select(v);
+    if (v == 0) {
+        /* Turning multi-select off: drop any lingering multi-selection so the
+           single-select rules apply cleanly on return to the life screen. */
+        selection_clear();
+    }
+}
+
 static const setting_item_t settings_items[] = {
     { .id = "brightness",     .fixed_label = "Brightness", .navigate = open_settings_screen, .nav_screen = &screen_settings },
     { .id = "autodim",        .label = autodim_label,          .color = autodim_color,     .get = autodim_get,              .set = autodim_set,              .count = AUTO_DIM_COUNT },
@@ -277,6 +292,7 @@ static const setting_item_t settings_items[] = {
     { .id = "orientation",    .label = orientation_mode_label, .color = orientation_color, .get = nvs_get_orientation,      .set = nvs_set_orientation,      .count = ORIENTATION_MODE_COUNT },
     { .id = "auto-eliminate", .label = auto_eliminate_label,   .color = toggle_color,      .get = nvs_get_auto_eliminate,   .set = nvs_set_auto_eliminate,   .count = 2 },
     { .id = "random-first",   .label = random_first_label,     .color = toggle_color,      .get = nvs_get_random_first,     .set = nvs_set_random_first,     .count = 2 },
+    { .id = "multi-select",   .label = multi_select_label,     .color = toggle_color,      .get = nvs_get_multi_select,     .set = multi_select_set,         .count = 2 },
 };
 #define SETTINGS_ITEM_COUNT ((int)(sizeof(settings_items) / sizeof(settings_items[0])))
 #define MAX_SETTINGS_PAGES  ((SETTINGS_ITEM_COUNT + 2) / 3)

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -263,6 +263,11 @@ void open_battery_screen(void)
     lv_scr_load(screen_battery);
 }
 
+static const char *random_first_label(int val)
+{
+    return val ? "Random\nFirst\nON" : "Random\nFirst\nOFF";
+}
+
 static const setting_item_t settings_items[] = {
     { .id = "brightness",     .fixed_label = "Brightness", .navigate = open_settings_screen, .nav_screen = &screen_settings },
     { .id = "autodim",        .label = autodim_label,          .color = autodim_color,     .get = autodim_get,              .set = autodim_set,              .count = AUTO_DIM_COUNT },
@@ -271,6 +276,7 @@ static const setting_item_t settings_items[] = {
     { .id = "deselect",       .label = deselect_label,         .color = deselect_color,    .get = nvs_get_deselect_timeout, .set = nvs_set_deselect_timeout, .count = DESELECT_COUNT },
     { .id = "orientation",    .label = orientation_mode_label, .color = orientation_color, .get = nvs_get_orientation,      .set = nvs_set_orientation,      .count = ORIENTATION_MODE_COUNT },
     { .id = "auto-eliminate", .label = auto_eliminate_label,   .color = toggle_color,      .get = nvs_get_auto_eliminate,   .set = nvs_set_auto_eliminate,   .count = 2 },
+    { .id = "random-first",   .label = random_first_label,     .color = toggle_color,      .get = nvs_get_random_first,     .set = nvs_set_random_first,     .count = 2 },
 };
 #define SETTINGS_ITEM_COUNT ((int)(sizeof(settings_items) / sizeof(settings_items[0])))
 #define MAX_SETTINGS_PAGES  ((SETTINGS_ITEM_COUNT + 2) / 3)

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -1,6 +1,7 @@
 #include "settings.h"
 #include "hw.h"
 #include "storage.h"
+#include <string.h>
 #include "dice.h"
 #include "timer.h"
 #include "game_mode.h"
@@ -16,22 +17,10 @@ extern void back_to_main(void);
 // ---------- screens ----------
 lv_obj_t *screen_quad_menu = NULL;
 lv_obj_t *screen_tools_menu = NULL;
-lv_obj_t *screen_screen_settings_menu = NULL;
-lv_obj_t *screen_settings_page2 = NULL;
 lv_obj_t *screen_settings = NULL;
 lv_obj_t *screen_battery = NULL;
 
 // ---------- widgets ----------
-static lv_obj_t *btn_autodim = NULL;
-static lv_obj_t *label_autodim_quad = NULL;
-static lv_obj_t *btn_color_mode = NULL;
-static lv_obj_t *label_color_mode_quad = NULL;
-static lv_obj_t *btn_deselect = NULL;
-static lv_obj_t *label_deselect_quad = NULL;
-static lv_obj_t *btn_orientation = NULL;
-static lv_obj_t *label_orientation_quad = NULL;
-static lv_obj_t *btn_auto_eliminate = NULL;
-static lv_obj_t *label_auto_eliminate_quad = NULL;
 static lv_obj_t *arc_brightness = NULL;
 static lv_obj_t *label_settings_value = NULL;
 static lv_obj_t *label_settings_hint = NULL;
@@ -66,7 +55,7 @@ void build_quad_screen(lv_obj_t **screen, quad_item_t items[4])
         lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, 0);
 
         if (items[i].cb != NULL && items[i].enabled) {
-            lv_obj_add_event_cb(btn, items[i].cb, items[i].event, NULL);
+            lv_obj_add_event_cb(btn, items[i].cb, items[i].event, items[i].user_data);
             lv_obj_set_style_bg_color(btn, lv_color_hex(0x1A1A2E), 0);
         } else {
             lv_obj_set_style_bg_color(btn, lv_color_hex(0x111111), 0);
@@ -198,13 +187,7 @@ static uint32_t deselect_color(int index)
 static void event_quad_screen_settings(lv_event_t *e)
 {
     (void)e;
-    lv_scr_load(screen_screen_settings_menu);
-}
-
-static void event_screen_brightness(lv_event_t *e)
-{
-    (void)e;
-    open_settings_screen();
+    lv_scr_load(settings_pages[0]);
 }
 
 static const char *autodim_label(int index)
@@ -217,39 +200,12 @@ static const char *autodim_label(int index)
     }
 }
 
-static void event_screen_autodim(lv_event_t *e)
-{
-    (void)e;
-    auto_dim_setting = (auto_dim_setting + 1) % AUTO_DIM_COUNT;
-    nvs_set_auto_dim(auto_dim_setting);
-    if (auto_dim_setting == AUTO_DIM_OFF && dimmed) {
-        dimmed = false;
-        brightness_apply();
-    }
-    if (label_autodim_quad) {
-        lv_label_set_text(label_autodim_quad, autodim_label(auto_dim_setting));
-    }
-    set_btn_color(btn_autodim, autodim_color(auto_dim_setting));
-}
-
 static const char *color_mode_label(int mode)
 {
     switch (mode) {
         case COLOR_MODE_LIFE:   return "Colors\nLife";
         default:                return "Colors\nPlayer";
     }
-}
-
-static void event_screen_color_mode(lv_event_t *e)
-{
-    int mode;
-    (void)e;
-    mode = (nvs_get_color_mode() + 1) % COLOR_MODE_COUNT;
-    nvs_set_color_mode(mode);
-    if (label_color_mode_quad) {
-        lv_label_set_text(label_color_mode_quad, color_mode_label(mode));
-    }
-    set_btn_color(btn_color_mode, color_mode_color(mode));
 }
 
 static const char *deselect_label(int index)
@@ -271,59 +227,168 @@ static const char *orientation_mode_label(int mode)
     }
 }
 
-static void event_screen_deselect(lv_event_t *e)
-{
-    int val;
-    (void)e;
-    val = (nvs_get_deselect_timeout() + 1) % DESELECT_COUNT;
-    nvs_set_deselect_timeout(val);
-    if (label_deselect_quad) {
-        lv_label_set_text(label_deselect_quad, deselect_label(val));
-    }
-    set_btn_color(btn_deselect, deselect_color(val));
-}
-
-static void event_screen_orientation(lv_event_t *e)
-{
-    int val;
-    (void)e;
-    val = (nvs_get_orientation() + 1) % ORIENTATION_MODE_COUNT;
-    nvs_set_orientation(val);
-    if (label_orientation_quad) {
-        lv_label_set_text(label_orientation_quad, orientation_mode_label(val));
-    }
-    set_btn_color(btn_orientation, orientation_color(val));
-}
-
 static const char *auto_eliminate_label(int val)
 {
     return val ? "Auto\nElimination\nON" : "Auto\nElimination\nOFF";
 }
 
-static void event_screen_auto_eliminate(lv_event_t *e)
+// ---------- declarative settings ----------
+/* Every user setting lives in this one table. Pages, "More" chaining,
+   back-navigation, and sim navigation are all derived from it: to add,
+   remove, or reorder a setting, edit only this table (plus its label,
+   color, and NVS functions). Label fns must return strings that
+   lv_label_set_text may copy — never switch the refresh to
+   lv_label_set_text_static. */
+
+static int autodim_get(void) { return auto_dim_setting; }
+static void autodim_set(int v)
 {
-    int val;
-    (void)e;
-    val = !nvs_get_auto_eliminate();
-    nvs_set_auto_eliminate(val);
-    if (label_auto_eliminate_quad) {
-        lv_label_set_text(label_auto_eliminate_quad, auto_eliminate_label(val));
+    auto_dim_setting = v;
+    nvs_set_auto_dim(v);
+    if (v == AUTO_DIM_OFF && dimmed) {
+        dimmed = false;
+        brightness_apply();
     }
-    set_btn_color(btn_auto_eliminate, val ? TOGGLE_ON : TOGGLE_OFF);
 }
 
-static void event_screen_more(lv_event_t *e)
+static uint32_t toggle_color(int val)
 {
-    (void)e;
-    lv_scr_load(screen_settings_page2);
+    return val ? TOGGLE_ON : TOGGLE_OFF;
 }
 
-static void event_screen_battery(lv_event_t *e)
+void open_battery_screen(void)
 {
-    (void)e;
     update_battery_measurement(true);
     refresh_battery_ui();
     lv_scr_load(screen_battery);
+}
+
+static const setting_item_t settings_items[] = {
+    { .id = "brightness",     .fixed_label = "Brightness", .navigate = open_settings_screen, .nav_screen = &screen_settings },
+    { .id = "autodim",        .label = autodim_label,          .color = autodim_color,     .get = autodim_get,              .set = autodim_set,              .count = AUTO_DIM_COUNT },
+    { .id = "battery",        .fixed_label = "Battery",    .navigate = open_battery_screen, .nav_screen = &screen_battery },
+    { .id = "color-mode",     .label = color_mode_label,       .color = color_mode_color,  .get = nvs_get_color_mode,       .set = nvs_set_color_mode,       .count = COLOR_MODE_COUNT },
+    { .id = "deselect",       .label = deselect_label,         .color = deselect_color,    .get = nvs_get_deselect_timeout, .set = nvs_set_deselect_timeout, .count = DESELECT_COUNT },
+    { .id = "orientation",    .label = orientation_mode_label, .color = orientation_color, .get = nvs_get_orientation,      .set = nvs_set_orientation,      .count = ORIENTATION_MODE_COUNT },
+    { .id = "auto-eliminate", .label = auto_eliminate_label,   .color = toggle_color,      .get = nvs_get_auto_eliminate,   .set = nvs_set_auto_eliminate,   .count = 2 },
+};
+#define SETTINGS_ITEM_COUNT ((int)(sizeof(settings_items) / sizeof(settings_items[0])))
+#define MAX_SETTINGS_PAGES  ((SETTINGS_ITEM_COUNT + 2) / 3)
+
+lv_obj_t *settings_pages[MAX_SETTINGS_PAGES];
+int settings_page_count = 0;
+static lv_obj_t *setting_btns[SETTINGS_ITEM_COUNT];
+static lv_obj_t *setting_lbls[SETTINGS_ITEM_COUNT];
+static int setting_page_of[SETTINGS_ITEM_COUNT];
+
+void refresh_settings_pages_ui(void)
+{
+    int i;
+    for (i = 0; i < SETTINGS_ITEM_COUNT; i++) {
+        const setting_item_t *it = &settings_items[i];
+        int v;
+        if (setting_btns[i] == NULL || it->get == NULL) continue;
+        v = it->get();
+        lv_label_set_text(setting_lbls[i], it->label(v));
+        set_btn_color(setting_btns[i], it->color ? it->color(v) : 0x1A1A2E);
+    }
+}
+
+static void event_setting_item(lv_event_t *e)
+{
+    const setting_item_t *it = lv_event_get_user_data(e);
+    if (it == NULL) return;
+    if (it->navigate != NULL) {
+        it->navigate();
+        return;
+    }
+    it->set((it->get() + 1) % it->count);
+    refresh_settings_pages_ui();
+}
+
+static void event_setting_more(lv_event_t *e)
+{
+    int page = (int)(intptr_t)lv_event_get_user_data(e);
+    if (page >= 0 && page < settings_page_count)
+        lv_scr_load(settings_pages[page]);
+}
+
+/* Chunk the flat item list into quad pages: 3 items + "More" per page,
+   except the last page which holds up to 4. */
+static void build_settings_pages(void)
+{
+    int idx = 0;
+    int page = 0;
+
+    while (idx < SETTINGS_ITEM_COUNT) {
+        int remaining = SETTINGS_ITEM_COUNT - idx;
+        int on_page = (remaining <= 4) ? remaining : 3;
+        int first = idx;
+        int s;
+        quad_item_t q[4];
+
+        memset(q, 0, sizeof(q));
+        for (s = 0; s < 4; s++) q[s].label = "";
+        for (s = 0; s < on_page; s++, idx++) {
+            const setting_item_t *it = &settings_items[idx];
+            q[s].label = (it->label != NULL) ? it->label(it->get()) : it->fixed_label;
+            q[s].cb = event_setting_item;
+            q[s].enabled = true;
+            q[s].event = (it->event != 0) ? it->event : LV_EVENT_CLICKED;
+            q[s].user_data = (void *)it;
+            setting_page_of[idx] = page;
+        }
+        if (remaining > 4) {
+            q[3].label = "More";
+            q[3].cb = event_setting_more;
+            q[3].enabled = true;
+            q[3].event = LV_EVENT_CLICKED;
+            q[3].user_data = (void *)(intptr_t)(page + 1);
+        }
+        build_quad_screen(&settings_pages[page], q);
+        for (s = 0; s < on_page; s++) {
+            setting_btns[first + s] = lv_obj_get_child(settings_pages[page], s);
+            setting_lbls[first + s] = lv_obj_get_child(setting_btns[first + s], 0);
+        }
+        page++;
+    }
+    settings_page_count = page;
+    refresh_settings_pages_ui();
+}
+
+bool settings_handle_back(lv_obj_t *screen)
+{
+    int i;
+
+    for (i = 0; i < SETTINGS_ITEM_COUNT; i++) {
+        if (settings_items[i].nav_screen != NULL && screen == *settings_items[i].nav_screen) {
+            if (screen == screen_settings) settings_save();
+            lv_scr_load(settings_pages[setting_page_of[i]]);
+            return true;
+        }
+    }
+    for (i = 0; i < settings_page_count; i++) {
+        if (screen == settings_pages[i]) {
+            if (i == 0) {
+                settings_save();
+                lv_scr_load(screen_quad_menu);
+            } else {
+                lv_scr_load(settings_pages[i - 1]);
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+int settings_item_page(const char *id)
+{
+    int i;
+    for (i = 0; i < SETTINGS_ITEM_COUNT; i++) {
+        if (strcmp(settings_items[i].id, id) == 0)
+            return setting_page_of[i];
+    }
+    return -1;
 }
 
 static void event_quad_tools(lv_event_t *e)
@@ -372,41 +437,7 @@ void build_quad_menus(void)
     };
     build_quad_screen(&screen_tools_menu, tools_items);
 
-    quad_item_t screen_items[4] = {
-        {"Brightness", event_screen_brightness, true, LV_EVENT_CLICKED},
-        {autodim_label(auto_dim_setting), event_screen_autodim, true, LV_EVENT_CLICKED},
-        {"Battery",       event_screen_battery, true, LV_EVENT_CLICKED},
-        {"More",          event_screen_more, true, LV_EVENT_CLICKED},
-    };
-    build_quad_screen(&screen_screen_settings_menu, screen_items);
-
-    btn_autodim = lv_obj_get_child(screen_screen_settings_menu, 1);
-    label_autodim_quad = lv_obj_get_child(btn_autodim, 0);
-    set_btn_color(btn_autodim, autodim_color(auto_dim_setting));
-
-    quad_item_t page2_items[4] = {
-        {color_mode_label(nvs_get_color_mode()), event_screen_color_mode, true, LV_EVENT_CLICKED},
-        {deselect_label(nvs_get_deselect_timeout()), event_screen_deselect, true, LV_EVENT_CLICKED},
-        {orientation_mode_label(nvs_get_orientation()), event_screen_orientation, true, LV_EVENT_CLICKED},
-        {auto_eliminate_label(nvs_get_auto_eliminate()), event_screen_auto_eliminate, true, LV_EVENT_CLICKED},
-    };
-    build_quad_screen(&screen_settings_page2, page2_items);
-
-    btn_color_mode = lv_obj_get_child(screen_settings_page2, 0);
-    label_color_mode_quad = lv_obj_get_child(btn_color_mode, 0);
-    set_btn_color(btn_color_mode, color_mode_color(nvs_get_color_mode()));
-
-    btn_deselect = lv_obj_get_child(screen_settings_page2, 1);
-    label_deselect_quad = lv_obj_get_child(btn_deselect, 0);
-    set_btn_color(btn_deselect, deselect_color(nvs_get_deselect_timeout()));
-
-    btn_orientation = lv_obj_get_child(screen_settings_page2, 2);
-    label_orientation_quad = lv_obj_get_child(btn_orientation, 0);
-    set_btn_color(btn_orientation, orientation_color(nvs_get_orientation()));
-
-    btn_auto_eliminate = lv_obj_get_child(screen_settings_page2, 3);
-    label_auto_eliminate_quad = lv_obj_get_child(btn_auto_eliminate, 0);
-    set_btn_color(btn_auto_eliminate, nvs_get_auto_eliminate() ? TOGGLE_ON : TOGGLE_OFF);
+    build_settings_pages();
 }
 
 void build_settings_screen(void)

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -240,10 +240,9 @@ static const char *auto_eliminate_label(int val)
    lv_label_set_text may copy — never switch the refresh to
    lv_label_set_text_static. */
 
-static int autodim_get(void) { return auto_dim_setting; }
+static int autodim_get(void) { return nvs_get_auto_dim(); }
 static void autodim_set(int v)
 {
-    auto_dim_setting = v;
     nvs_set_auto_dim(v);
     if (v == AUTO_DIM_OFF && dimmed) {
         dimmed = false;

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -433,7 +433,6 @@ static void event_open_damage_log(lv_event_t *e)
 static void event_general_reset(lv_event_t *e)
 {
     (void)e;
-    damage_log_reset();
     reset_all_values();
     back_to_main();
     lv_indev_wait_release(lv_indev_get_act());

--- a/knobby/src/settings.h
+++ b/knobby/src/settings.h
@@ -6,10 +6,28 @@
 // ---------- screens ----------
 extern lv_obj_t *screen_quad_menu;
 extern lv_obj_t *screen_tools_menu;
-extern lv_obj_t *screen_screen_settings_menu;
-extern lv_obj_t *screen_settings_page2;
 extern lv_obj_t *screen_settings;
 extern lv_obj_t *screen_battery;
+
+// ---------- declarative settings ----------
+/* One table in settings.c defines every user setting; pages and
+   navigation are derived from it. */
+typedef struct {
+    const char *id;              /* stable id for sim navigation: "autodim" */
+    const char *fixed_label;     /* used when label == NULL (navigation items) */
+    const char *(*label)(int v); /* value -> text */
+    uint32_t (*color)(int v);    /* value -> bg color; NULL = default */
+    int (*get)(void);            /* NULL => navigation item */
+    void (*set)(int v);          /* writes NVS + side effects */
+    int count;                   /* cycle modulo (2 for ON/OFF toggles) */
+    void (*navigate)(void);      /* non-NULL => click opens a sub-screen */
+    lv_obj_t **nav_screen;       /* sub-screen global, for generic back-nav */
+    lv_event_code_t event;       /* trigger; 0 = LV_EVENT_CLICKED (use
+                                    LV_EVENT_LONG_PRESSED for "Hold" items) */
+} setting_item_t;
+
+extern lv_obj_t *settings_pages[];
+extern int settings_page_count;
 
 // ---------- functions ----------
 void build_quad_screen(lv_obj_t **screen, quad_item_t items[4]);
@@ -18,9 +36,14 @@ void build_settings_screen(void);
 void build_battery_screen(void);
 
 void refresh_settings_ui(void);
+void refresh_settings_pages_ui(void);
 void refresh_battery_ui(void);
+
+bool settings_handle_back(lv_obj_t *screen);
+int settings_item_page(const char *id);
 
 void open_quad_menu(void);
 void open_settings_screen(void);
+void open_battery_screen(void);
 
 #endif // _SETTINGS_H

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -14,6 +14,7 @@ static int cached_num_players = 4;
 static int cached_players_to_track = 1;
 static int cached_life_total = DEFAULT_LIFE_TOTAL;
 static int cached_auto_eliminate = 1; /* 1=ON (default), 0=OFF */
+static int cached_random_first = 1; /* 1=ON (default): random first-player pick on reset */
 static char cached_name_list[NAME_LIST_COUNT][NAME_LIST_LEN];
 
 // ---------- init ----------
@@ -59,6 +60,10 @@ void knob_nvs_init(void)
         int8_t ae_val = 1;
         nvs_get_i8(handle, "auto_elim", &ae_val);
         cached_auto_eliminate = (ae_val != 0) ? 1 : 0;
+
+        int8_t rf_val = 1;
+        nvs_get_i8(handle, "rand_first", &rf_val);
+        cached_random_first = (rf_val != 0) ? 1 : 0;
 
         size_t nl_size = sizeof(cached_name_list);
         nvs_get_blob(handle, "name_list", cached_name_list, &nl_size);
@@ -174,6 +179,18 @@ void nvs_set_auto_eliminate(int value)
     settings_dirty = true;
 }
 
+// ---------- random first-player pick ----------
+int nvs_get_random_first(void)
+{
+    return cached_random_first;
+}
+
+void nvs_set_random_first(int value)
+{
+    cached_random_first = (value != 0) ? 1 : 0;
+    settings_dirty = true;
+}
+
 // ---------- name list ----------
 void nvs_get_name_list(char (*out)[NAME_LIST_LEN])
 {
@@ -201,6 +218,7 @@ void settings_save(void)
         nvs_set_i8(handle, "track", (int8_t)cached_players_to_track);
         nvs_set_i16(handle, "life_total", (int16_t)cached_life_total);
         nvs_set_i8(handle, "auto_elim", (int8_t)cached_auto_eliminate);
+        nvs_set_i8(handle, "rand_first", (int8_t)cached_random_first);
         nvs_set_blob(handle, "name_list", cached_name_list, sizeof(cached_name_list));
         nvs_commit(handle);
         nvs_close(handle);

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -15,6 +15,7 @@ static int cached_players_to_track = 1;
 static int cached_life_total = DEFAULT_LIFE_TOTAL;
 static int cached_auto_eliminate = 1; /* 1=ON (default), 0=OFF */
 static int cached_random_first = 1; /* 1=ON (default): random first-player pick on reset */
+static int cached_multi_select = 0; /* 0=OFF (default), 1=ON */
 static char cached_name_list[NAME_LIST_COUNT][NAME_LIST_LEN];
 
 // ---------- init ----------
@@ -64,6 +65,10 @@ void knob_nvs_init(void)
         int8_t rf_val = 1;
         nvs_get_i8(handle, "rand_first", &rf_val);
         cached_random_first = (rf_val != 0) ? 1 : 0;
+
+        int8_t ms_val = 0;
+        nvs_get_i8(handle, "multi_sel", &ms_val);
+        cached_multi_select = (ms_val != 0) ? 1 : 0;
 
         size_t nl_size = sizeof(cached_name_list);
         nvs_get_blob(handle, "name_list", cached_name_list, &nl_size);
@@ -191,6 +196,18 @@ void nvs_set_random_first(int value)
     settings_dirty = true;
 }
 
+// ---------- multi-select ----------
+int nvs_get_multi_select(void)
+{
+    return cached_multi_select;
+}
+
+void nvs_set_multi_select(int value)
+{
+    cached_multi_select = (value != 0) ? 1 : 0;
+    settings_dirty = true;
+}
+
 // ---------- name list ----------
 void nvs_get_name_list(char (*out)[NAME_LIST_LEN])
 {
@@ -219,6 +236,7 @@ void settings_save(void)
         nvs_set_i16(handle, "life_total", (int16_t)cached_life_total);
         nvs_set_i8(handle, "auto_elim", (int8_t)cached_auto_eliminate);
         nvs_set_i8(handle, "rand_first", (int8_t)cached_random_first);
+        nvs_set_i8(handle, "multi_sel", (int8_t)cached_multi_select);
         nvs_set_blob(handle, "name_list", cached_name_list, sizeof(cached_name_list));
         nvs_commit(handle);
         nvs_close(handle);

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -56,7 +56,11 @@ void knob_nvs_init(void)
         cached_brightness = clamp_brightness(bri_val);
         cached_num_players = (np_val < 1) ? 1 : (np_val > MAX_GAME_PLAYERS) ? MAX_GAME_PLAYERS : np_val;
         cached_players_to_track = (pt_val < 1) ? 1 : (pt_val > MAX_DISPLAY_PLAYERS) ? MAX_DISPLAY_PLAYERS : pt_val;
-        cached_life_total = (lt_val < 0) ? 0 : (lt_val > LIFE_MAX) ? LIFE_MAX : lt_val;
+        /* Every consumer assumes track <= num_players; foreign/old NVS could
+           store an inconsistent pair that the per-field clamps above allow. */
+        if (cached_players_to_track > cached_num_players)
+            cached_players_to_track = cached_num_players;
+        cached_life_total = (lt_val < 1) ? 1 : (lt_val > LIFE_MAX) ? LIFE_MAX : lt_val;
 
         int8_t ae_val = 1;
         nvs_get_i8(handle, "auto_elim", &ae_val);
@@ -168,7 +172,7 @@ int nvs_get_life_total(void)
 
 void nvs_set_life_total(int value)
 {
-    cached_life_total = (value < 0) ? 0 : (value > LIFE_MAX) ? LIFE_MAX : value;
+    cached_life_total = (value < 1) ? 1 : (value > LIFE_MAX) ? LIFE_MAX : value;
     settings_dirty = true;
 }
 
@@ -238,8 +242,12 @@ void settings_save(void)
         nvs_set_i8(handle, "rand_first", (int8_t)cached_random_first);
         nvs_set_i8(handle, "multi_sel", (int8_t)cached_multi_select);
         nvs_set_blob(handle, "name_list", cached_name_list, sizeof(cached_name_list));
-        nvs_commit(handle);
+        esp_err_t commit_err = nvs_commit(handle);
         nvs_close(handle);
-        settings_dirty = false;
+        /* Keep the dirty flag set if the commit failed (e.g. NVS full) so a
+           later save retries instead of silently dropping the change. */
+        if (commit_err == ESP_OK) {
+            settings_dirty = false;
+        }
     }
 }

--- a/knobby/src/storage.h
+++ b/knobby/src/storage.h
@@ -28,6 +28,9 @@ void nvs_set_life_total(int value);
 int nvs_get_auto_eliminate(void);
 void nvs_set_auto_eliminate(int value);
 
+int nvs_get_random_first(void);
+void nvs_set_random_first(int value);
+
 #define NAME_LIST_COUNT 10
 #define NAME_LIST_LEN   16
 void nvs_get_name_list(char (*out)[NAME_LIST_LEN]);

--- a/knobby/src/storage.h
+++ b/knobby/src/storage.h
@@ -31,6 +31,9 @@ void nvs_set_auto_eliminate(int value);
 int nvs_get_random_first(void);
 void nvs_set_random_first(int value);
 
+int nvs_get_multi_select(void);
+void nvs_set_multi_select(int value);
+
 #define NAME_LIST_COUNT 10
 #define NAME_LIST_LEN   16
 void nvs_get_name_list(char (*out)[NAME_LIST_LEN]);

--- a/knobby/src/types.h
+++ b/knobby/src/types.h
@@ -69,6 +69,7 @@ typedef struct {
     lv_event_code_t event;
     const char *icon;
     const lv_font_t *icon_font;
+    void *user_data;            /* passed to cb via lv_event_get_user_data */
 } quad_item_t;
 
 // ---------- utility functions ----------

--- a/knobby/src/types.h
+++ b/knobby/src/types.h
@@ -59,7 +59,6 @@ typedef struct {
 
 typedef struct {
     knob_event_t event;
-    int cont;
 } knob_input_event_t;
 
 typedef struct {

--- a/knobby/src/ui_1p.c
+++ b/knobby/src/ui_1p.c
@@ -218,7 +218,6 @@ static void style_select_entry(int i, int player_index)
         lv_obj_set_style_text_color(label_enemy_damage[i], text_color, 0);
         lv_obj_set_style_bg_color(select_rows[i], get_player_base_color(player_index), 0);
         lv_obj_set_style_bg_opa(select_rows[i], LV_OPA_COVER, 0);
-        lv_obj_clear_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
         lv_obj_add_flag(select_rows[i], LV_OBJ_FLAG_CLICKABLE);
     }
 

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -312,14 +312,14 @@ static void refresh_counter_rows(lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **va
 static lv_color_t refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t *name_lbl, int i, int color_i)
 {
     char buf[8];
-    bool preview_here = life_preview_active && (preview_player == i);
-    bool selected = (i == selected_player);
+    bool selected = is_player_selected(i);
+    bool preview_here = life_preview_active && selected;
     lv_color_t bg_color;
     lv_color_t text_color;
 
     {
         int vib;
-        if (selected_player < 0) vib = LIFE_VIB_MID;
+        if (selection_count() == 0) vib = LIFE_VIB_MID;
         else vib = selected ? LIFE_VIB_VIV : LIFE_VIB_DIM;
         bg_color = get_effective_player_color(i, color_i, vib);
         text_color = color_is_light(bg_color) ? lv_color_black() : lv_color_white();
@@ -433,21 +433,44 @@ void refresh_multiplayer_ui(void)
 static void event_multiplayer_select(lv_event_t *e)
 {
     int player = (int)(intptr_t)lv_event_get_user_data(e);
+    bool had_pending;
+    bool was_selected;
 
     if (player < 0 || player >= MULTIPLAYER_COUNT) return;
     if (player_eliminated[player]) return;
 
-    if (life_preview_active && preview_player != player) {
+    /* Capture state before committing: the commit clears the selection in
+       multi-select mode, so we can't read it afterwards. */
+    had_pending = life_preview_active;
+    was_selected = is_player_selected(player);
+
+    /* Apply any pending delta to the current set before the selection
+       changes. */
+    if (life_preview_active) {
         life_preview_commit_cb(NULL);
     }
 
-    if (selected_player == player) {
-        if (life_preview_active && preview_player == player) {
-            life_preview_commit_cb(NULL);
+    if (nvs_get_multi_select()) {
+        if (had_pending) {
+            /* A pending change was just applied (and the set cleared).
+               Tapping a player that was part of the set ends the operation
+               with nothing selected; tapping a different player starts a
+               fresh selection with just that player. */
+            if (!was_selected) {
+                selection_set_single(player);
+            }
+        } else {
+            /* No pending change: tap toggles this player in/out of the set. */
+            selection_toggle(player);
         }
-        selected_player = -1;
     } else {
-        selected_player = player;
+        /* Single-select (default): tapping the only selected player deselects;
+           tapping any other player switches the selection to it. */
+        if (was_selected && selection_count() == 1) {
+            selection_clear();
+        } else {
+            selection_set_single(player);
+        }
     }
     select_kick_timer();
     refresh_multiplayer_ui();
@@ -461,8 +484,8 @@ static void event_multiplayer_open_menu(lv_event_t *e)
 
     /* A long-press is a deliberate gesture, so it always opens the
        pressed player's menu (e.g. to apply commander damage), even when
-       another player is selected for life changes; the selection is left
-       untouched. */
+       one or more players are selected for life changes; the selection
+       is left untouched. */
     if (player_eliminated[player]) {
         menu_player = player;
         load_screen_if_needed(screen_eliminated_player_menu);
@@ -482,7 +505,7 @@ static void event_multiplayer_open_menu(lv_event_t *e)
 static void select_timeout_cb(lv_timer_t *timer)
 {
     (void)timer;
-    selected_player = -1;
+    selection_clear();
     if (select_timeout_timer != NULL)
         lv_timer_pause(select_timeout_timer);
     refresh_multiplayer_ui();
@@ -497,7 +520,7 @@ void select_kick_timer(void)
         select_timeout_timer = lv_timer_create(select_timeout_cb, 15000, NULL);
         lv_timer_pause(select_timeout_timer);
     }
-    if (selected_player >= 0 && ms > 0) {
+    if (selection_count() > 0 && ms > 0) {
         lv_timer_set_period(select_timeout_timer, (uint32_t)ms);
         lv_timer_reset(select_timeout_timer);
         lv_timer_resume(select_timeout_timer);

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -821,8 +821,3 @@ void build_multiplayer_screen(void)
     rebuild_multiplayer_layout(nvs_get_players_to_track());
 }
 
-void open_multiplayer_screen(void)
-{
-    refresh_multiplayer_ui();
-    load_screen_if_needed(screen_multiplayer);
-}

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -560,6 +560,15 @@ static void event_multiplayer_select(lv_event_t *e)
     if (player < 0 || player >= MULTIPLAYER_COUNT) return;
     if (player_eliminated[player]) return;
 
+    /* A tap during the first-player roulette stops the spin and leaves
+       nothing selected (the spinning highlight is not a real selection). */
+    if (player_selection_animation_active()) {
+        stop_player_selection_animation();
+        selection_clear();
+        refresh_multiplayer_ui();
+        return;
+    }
+
     /* Capture state before committing: the commit clears the selection in
        multi-select mode, so we can't read it afterwards. */
     had_pending = life_preview_active;
@@ -603,6 +612,17 @@ static void event_multiplayer_open_menu(lv_event_t *e)
 
     if (player < 0 || player >= MULTIPLAYER_COUNT) return;
 
+    if (player_selection_animation_active()) {
+        stop_player_selection_animation();
+        selection_clear();
+    }
+
+    /* Resolve any pending dialed delta before leaving the screen, so the
+       auto-commit can't fire later against a context the user left. */
+    if (life_preview_active) {
+        life_preview_commit_cb(NULL);
+    }
+
     /* A long-press is a deliberate gesture, so it always opens the
        pressed player's menu (e.g. to apply commander damage), even when
        one or more players are selected for life changes; the selection
@@ -614,10 +634,6 @@ static void event_multiplayer_open_menu(lv_event_t *e)
         return;
     }
 
-    if (life_preview_active) {
-        life_preview_commit_cb(NULL);
-    }
-
     open_player_menu(player);
     lv_indev_wait_release(lv_indev_get_act());
 }
@@ -626,6 +642,12 @@ static void event_multiplayer_open_menu(lv_event_t *e)
 static void select_timeout_cb(lv_timer_t *timer)
 {
     (void)timer;
+    /* Apply a still-pending dialed delta rather than silently dropping it.
+       (Today the 3s preview always commits before the >=5s timeout, but
+       nothing else enforces that ordering.) */
+    if (life_preview_active) {
+        life_preview_commit_cb(NULL);
+    }
     selection_clear();
     if (select_timeout_timer != NULL)
         lv_timer_pause(select_timeout_timer);

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -29,7 +29,72 @@ typedef struct {
     lv_coord_t nudge_x;     /* x offset for life/name labels in non-centric modes */
     int player_index;       /* which player this panel displays */
     int color_index;        /* color slot (differs from player only for 2p) */
+    /* Pie-slice panels: full-screen with an angular wedge mask. Angles use
+       the LVGL arc convention (0 = 3 o'clock, clockwise, degrees). Both 0
+       means a plain rectangular panel. All slice geometry — label anchors,
+       text rotation, counter arc, separators — derives from these angles
+       at layout-build time. */
+    int16_t wedge_start;
+    int16_t wedge_end;
 } mp_panel_spec_t;
+
+static bool spec_is_wedge(const mp_panel_spec_t *spec)
+{
+    return spec->wedge_start != spec->wedge_end;
+}
+
+/* ---------- wedge geometry, derived once per layout rebuild ----------
+   Everything that depends on the slice angles (label anchors, text
+   rotation, counter arc, separators) reads this cache, so the spec's
+   wedge_start/wedge_end stay the single source of truth and refresh/draw
+   paths do no trigonometry. */
+#define WEDGE_CX 180
+#define WEDGE_CY 180
+#define WEDGE_LABEL_RADIUS 88
+
+typedef struct {
+    int16_t bis_deg;                /* slice bisector angle */
+    lv_coord_t label_dx, label_dy;  /* label anchor offset from center */
+} wedge_geom_t;
+
+static wedge_geom_t wedge_geom[MULTIPLAYER_COUNT];
+static lv_point_t wedge_sep_ends[MULTIPLAYER_COUNT];
+static int wedge_sep_count = 0;
+
+/* Round an lv_trigo_sin/cos value (scaled 1<<15) projected to a radius */
+static lv_coord_t wedge_polar(int16_t trig, int radius)
+{
+    int32_t v = (int32_t)trig * radius;
+    return (lv_coord_t)((v + (v >= 0 ? 16384 : -16384)) / 32768);
+}
+
+static int16_t wedge_bisector_deg(const mp_panel_spec_t *spec)
+{
+    int delta = (spec->wedge_end >= spec->wedge_start)
+              ? spec->wedge_end - spec->wedge_start
+              : 360 - spec->wedge_start + spec->wedge_end;
+    return (int16_t)((spec->wedge_start + delta / 2) % 360);
+}
+
+static void wedge_compute_geometry(const mp_panel_spec_t *panels, int panel_count)
+{
+    int i;
+
+    wedge_sep_count = 0;
+    for (i = 0; i < panel_count && i < MULTIPLAYER_COUNT; i++) {
+        const mp_panel_spec_t *spec = &panels[i];
+        int16_t bis = wedge_bisector_deg(spec);
+
+        wedge_geom[i].bis_deg = bis;
+        wedge_geom[i].label_dx = wedge_polar(lv_trigo_cos(bis), WEDGE_LABEL_RADIUS);
+        wedge_geom[i].label_dy = wedge_polar(lv_trigo_sin(bis), WEDGE_LABEL_RADIUS);
+
+        /* One boundary per panel covers every separator exactly once */
+        wedge_sep_ends[i].x = WEDGE_CX + wedge_polar(lv_trigo_cos(spec->wedge_start), 180);
+        wedge_sep_ends[i].y = WEDGE_CY + wedge_polar(lv_trigo_sin(spec->wedge_start), 180);
+        wedge_sep_count++;
+    }
+}
 
 typedef struct {
     int panel_count;
@@ -151,8 +216,13 @@ static void get_counter_equator_anchor(lv_obj_t *panel,
     *anchor_y = target_world_y - panel_center_y;
 }
 
-static int16_t get_counter_row_angle(int orientation_mode, lv_obj_t *panel, int16_t panel_angle)
+static int16_t get_counter_row_angle(int orientation_mode, const mp_panel_spec_t *spec,
+                                     lv_obj_t *panel, int16_t panel_angle)
 {
+    /* Wedge panels: counters follow the slice angle in every orientation,
+       matching the life/name labels */
+    if (spec_is_wedge(spec)) return panel_angle;
+
     if (orientation_mode == ORIENTATION_MODE_CENTRIC) {
         lv_obj_t *parent;
 
@@ -180,11 +250,10 @@ static int16_t get_2p_orientation_angle(int mode, int panel_index)
 
 static int16_t get_3p_orientation_angle(int mode, int panel_index)
 {
-    static const int16_t angled_rot[3] = {1350, 2250, 0};
-
     switch (mode) {
         case ORIENTATION_MODE_CENTRIC:
-            return angled_rot[panel_index];
+            /* Bisector minus 90 so text reads upright from each seat */
+            return (int16_t)(((wedge_geom[panel_index].bis_deg + 270) % 360) * 10);
         case ORIENTATION_MODE_TABLETOP:
             return (panel_index < 2) ? 1800 : 0;
         default:
@@ -213,11 +282,12 @@ static const mp_panel_spec_t panels_2p[] = {
     {0, 182, 360, 178, 0, 0, 1},
 };
 
-/* 3p: top-left = P2, top-right = P3, bottom = P1 */
+/* 3p: three equal 120-degree pie slices — top-left = P2, top-right = P3,
+   bottom = P1. Bisectors at 210/330/90 degrees. */
 static const mp_panel_spec_t panels_3p[] = {
-    {0,   0, 180, 180,  10, 1, 1},
-    {180, 0, 180, 180, -10, 2, 2},
-    {0, 180, 360, 180,   0, 0, 0},
+    {0, 0, 360, 360, 0, 1, 1, 150, 270},
+    {0, 0, 360, 360, 0, 2, 2, 270,  30},
+    {0, 0, 360, 360, 0, 0, 0,  30, 150},
 };
 
 /* 4p: quadrants in order P1, P2, P3, P4 */
@@ -257,7 +327,8 @@ static const mp_layout_spec_t *get_layout(int track)
 }
 
 /* ---------- per-panel refresh ---------- */
-static void refresh_counter_rows(lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **value_labels,
+static void refresh_counter_rows(const mp_panel_spec_t *spec, int16_t wedge_bis,
+                                 lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **value_labels,
                                  int player_index, lv_color_t text_color,
                                  int16_t panel_angle, int16_t row_angle)
 {
@@ -270,7 +341,9 @@ static void refresh_counter_rows(lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **va
     lv_coord_t anchor_y = 0;
 
     (void)panel_angle;
-    get_counter_equator_anchor(panel, &anchor_x, &anchor_y);
+    if (!spec_is_wedge(spec)) {
+        get_counter_equator_anchor(panel, &anchor_x, &anchor_y);
+    }
 
     for (type = 0; type < COUNTER_TYPE_COUNT; type++) {
         if (rows[type] == NULL || value_labels[type] == NULL) continue;
@@ -289,8 +362,23 @@ static void refresh_counter_rows(lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **va
         int value;
         int counter_type = visible_types[type];
         lv_coord_t x_offset = (lv_coord_t)((type * step) - ((visible_count - 1) * step / 2));
-        lv_coord_t local_x = anchor_x + x_offset;
-        lv_coord_t local_y = anchor_y;
+        lv_coord_t local_x;
+        lv_coord_t local_y;
+
+        if (spec_is_wedge(spec)) {
+            /* Badges on an arc near the rim, centered on the wedge
+               bisector: constant clearance from both the rim and the
+               life/name labels regardless of badge count. */
+            const int radius = 152;
+            const int step_deg = 12;
+            int a = (wedge_bis + ((visible_count - 1) * step_deg / 2)
+                     - (type * step_deg) + 360) % 360;
+            local_x = wedge_polar(lv_trigo_cos((int16_t)a), radius);
+            local_y = wedge_polar(lv_trigo_sin((int16_t)a), radius);
+        } else {
+            local_x = anchor_x + x_offset;
+            local_y = anchor_y;
+        }
 
         value = get_counter_value(player_index, (counter_type_t)counter_type);
 
@@ -393,38 +481,71 @@ void refresh_multiplayer_ui(void)
         lv_obj_t *life_lbl = mp_state.life_labels[i];
         lv_obj_t *name_lbl = mp_state.name_labels[i];
         int16_t angle = layout->angle_fn(orientation_mode, i);
-        int16_t counter_angle = get_counter_row_angle(orientation_mode, panel, angle);
+        int16_t counter_angle = get_counter_row_angle(orientation_mode, spec, panel, angle);
         lv_coord_t nx = (orientation_mode != ORIENTATION_MODE_CENTRIC) ? spec->nudge_x : 0;
+        lv_coord_t bx = nx;
+        lv_coord_t by = 0;
         lv_color_t text_color;
+
+        if (spec_is_wedge(spec)) {
+            /* Wedge panels are full-screen: anchor the label stack on the
+               wedge bisector instead of the panel center. */
+            bx = wedge_geom[i].label_dx;
+            by = wedge_geom[i].label_dy;
+            if (angle == 1800) {
+                /* The 180-degree flip rotates the life/name pair around
+                   their shared pivot, moving the name ~30px toward the
+                   rim; pull the anchor inward to keep the same clearance
+                   from the counter arc as in absolute mode. */
+                bx = (lv_coord_t)((bx * 85) / 100);
+                by = (lv_coord_t)((by * 85) / 100);
+            }
+        }
 
         text_color = refresh_mp_panel(panel, life_lbl, name_lbl,
                                       spec->player_index, spec->color_index);
 
         if (layout->switch_font_by_orientation) {
+            const lv_font_t *life_font;
+            lv_coord_t life_pivot_y;
+
+            if (spec_is_wedge(spec)) {
+                /* Pie slices have room for the big font in every
+                   orientation; drop to the smaller one only when the
+                   value is too wide and would reach into the counter
+                   arc beside the number (3+ digits). */
+                life_font = &lv_font_montserrat_bold_56;
+                if (life_lbl != NULL) {
+                    lv_point_t ts;
+                    lv_txt_get_size(&ts, lv_label_get_text(life_lbl),
+                                    life_font, 0, 0, LV_COORD_MAX,
+                                    LV_TEXT_FLAG_NONE);
+                    if (ts.x > 84) life_font = &lv_font_montserrat_bold_44;
+                }
+            } else if (orientation_mode == ORIENTATION_MODE_CENTRIC) {
+                /* Rect quadrants: rotated bold-56 labels don't fit */
+                life_font = &lv_font_montserrat_bold_44;
+            } else {
+                life_font = &lv_font_montserrat_bold_56;
+            }
+            life_pivot_y = (life_font == &lv_font_montserrat_bold_56) ? 12 : 10;
+
             if (life_lbl != NULL) {
                 lv_obj_clear_flag(life_lbl, LV_OBJ_FLAG_HIDDEN);
-                if (orientation_mode == ORIENTATION_MODE_CENTRIC) {
-                    lv_obj_set_style_text_font(life_lbl, &lv_font_montserrat_bold_44, 0);
-                    lv_obj_align(life_lbl, LV_ALIGN_CENTER, nx, -10);
-                } else {
-                    lv_obj_set_style_text_font(life_lbl, &lv_font_montserrat_bold_56, 0);
-                    lv_obj_align(life_lbl, LV_ALIGN_CENTER, nx, -12);
-                }
+                lv_obj_set_style_text_font(life_lbl, life_font, 0);
+                lv_obj_align(life_lbl, LV_ALIGN_CENTER, bx, by - life_pivot_y);
             }
             if (name_lbl != NULL) {
                 lv_obj_clear_flag(name_lbl, LV_OBJ_FLAG_HIDDEN);
-                lv_obj_align(name_lbl, LV_ALIGN_CENTER, nx, 30);
+                lv_obj_align(name_lbl, LV_ALIGN_CENTER, bx, by + 30);
             }
-            if (orientation_mode == ORIENTATION_MODE_CENTRIC) {
-                apply_label_rotation(life_lbl, name_lbl, angle, 10, -30);
-            } else {
-                apply_label_rotation(life_lbl, name_lbl, angle, 12, -30);
-            }
+            apply_label_rotation(life_lbl, name_lbl, angle, life_pivot_y, -30);
         } else {
             apply_label_rotation(life_lbl, name_lbl, angle, 10, -30);
         }
 
-        refresh_counter_rows(panel, mp_state.counter_rows[i], mp_state.counter_values[i],
+        refresh_counter_rows(spec, wedge_geom[i].bis_deg, panel,
+                             mp_state.counter_rows[i], mp_state.counter_values[i],
                              spec->player_index, text_color, angle, counter_angle);
     }
 }
@@ -529,6 +650,70 @@ void select_kick_timer(void)
     }
 }
 
+/* ---------- pie-slice (wedge) panels ----------
+   Full-screen panels clipped to an angular wedge with a draw-time angle
+   mask (the arc widget's primitive), and hit-tested by angle so taps land
+   on the right slice. This avoids rotating containers, whose transform
+   layers would not fit in the LVGL heap. */
+static lv_draw_mask_angle_param_t wedge_mask_params[MULTIPLAYER_COUNT];
+static int16_t wedge_mask_ids[MULTIPLAYER_COUNT];
+
+static bool wedge_contains_angle(const mp_panel_spec_t *spec, int angle)
+{
+    if (spec->wedge_start <= spec->wedge_end)
+        return angle >= spec->wedge_start && angle < spec->wedge_end;
+    /* range wraps past 0 degrees */
+    return angle >= spec->wedge_start || angle < spec->wedge_end;
+}
+
+static void event_wedge_panel(lv_event_t *e)
+{
+    int idx = (int)(intptr_t)lv_event_get_user_data(e);
+    const mp_panel_spec_t *spec;
+    lv_event_code_t code = lv_event_get_code(e);
+
+    if (mp_state.layout == NULL || idx < 0 || idx >= mp_state.layout->panel_count)
+        return;
+    spec = &mp_state.layout->panels[idx];
+
+    if (code == LV_EVENT_COVER_CHECK) {
+        /* The wedge mask means this panel does not fully cover its
+           rectangle, so siblings underneath must still be drawn. */
+        lv_cover_check_info_t *info = lv_event_get_param(e);
+        info->res = LV_COVER_RES_MASKED;
+    } else if (code == LV_EVENT_DRAW_MAIN_BEGIN) {
+        lv_draw_mask_angle_init(&wedge_mask_params[idx], WEDGE_CX, WEDGE_CY,
+                                spec->wedge_start, spec->wedge_end);
+        wedge_mask_ids[idx] = lv_draw_mask_add(&wedge_mask_params[idx], NULL);
+    } else if (code == LV_EVENT_DRAW_MAIN_END) {
+        /* Remove before children draw so labels are not clipped */
+        lv_draw_mask_remove_id(wedge_mask_ids[idx]);
+    } else if (code == LV_EVENT_HIT_TEST) {
+        lv_hit_test_info_t *info = lv_event_get_param(e);
+        int dx = info->point->x - WEDGE_CX;
+        int dy = info->point->y - WEDGE_CY;
+        if (dx == 0 && dy == 0) dx = 1; /* lv_atan2 needs a non-zero vector */
+        /* lv_atan2(y, x) matches the mask/arc angle convention
+           (0 = 3 o'clock, clockwise) — same call order as lv_arc */
+        info->res = wedge_contains_angle(spec, lv_atan2(dy, dx));
+    }
+}
+
+static void event_wedge_separators(lv_event_t *e)
+{
+    static const lv_point_t sep_center = {WEDGE_CX, WEDGE_CY};
+    lv_draw_ctx_t *draw_ctx = lv_event_get_draw_ctx(e);
+    lv_draw_line_dsc_t dsc;
+    int s;
+
+    lv_draw_line_dsc_init(&dsc);
+    dsc.color = lv_color_black();
+    dsc.width = 2;
+    for (s = 0; s < wedge_sep_count; s++) {
+        lv_draw_line(draw_ctx, &dsc, &sep_center, &wedge_sep_ends[s]);
+    }
+}
+
 /* ---------- layout rebuild ---------- */
 void rebuild_multiplayer_layout(int track)
 {
@@ -546,6 +731,10 @@ void rebuild_multiplayer_layout(int track)
     memset(&mp_state, 0, sizeof(mp_state));
     mp_state.layout = layout;
 
+    if (layout->panel_count > 0 && spec_is_wedge(&layout->panels[0])) {
+        wedge_compute_geometry(layout->panels, layout->panel_count);
+    }
+
     for (i = 0; i < layout->panel_count; i++) {
         const mp_panel_spec_t *spec = &layout->panels[i];
         int p = spec->player_index;
@@ -560,9 +749,21 @@ void rebuild_multiplayer_layout(int track)
         lv_obj_set_size(panel, spec->w, spec->h);
         lv_obj_set_pos(panel, spec->x, spec->y);
         lv_obj_set_style_radius(panel, 0, 0);
-        lv_obj_set_style_border_width(panel, 1, 0);
-        lv_obj_set_style_border_color(panel, lv_color_black(), 0);
         lv_obj_set_style_shadow_width(panel, 0, 0);
+        if (spec_is_wedge(spec)) {
+            /* Wedges adjoin; separators are drawn as lines on top */
+            lv_obj_set_style_border_width(panel, 0, 0);
+            lv_obj_add_flag(panel, LV_OBJ_FLAG_ADV_HITTEST);
+            /* Register per event code so the dispatcher filters the many
+               events (presses, draw phases) the handler doesn't act on */
+            lv_obj_add_event_cb(panel, event_wedge_panel, LV_EVENT_COVER_CHECK, (void *)(intptr_t)i);
+            lv_obj_add_event_cb(panel, event_wedge_panel, LV_EVENT_DRAW_MAIN_BEGIN, (void *)(intptr_t)i);
+            lv_obj_add_event_cb(panel, event_wedge_panel, LV_EVENT_DRAW_MAIN_END, (void *)(intptr_t)i);
+            lv_obj_add_event_cb(panel, event_wedge_panel, LV_EVENT_HIT_TEST, (void *)(intptr_t)i);
+        } else {
+            lv_obj_set_style_border_width(panel, 1, 0);
+            lv_obj_set_style_border_color(panel, lv_color_black(), 0);
+        }
         lv_obj_add_event_cb(panel, event_multiplayer_select, LV_EVENT_SHORT_CLICKED, (void *)(intptr_t)p);
         lv_obj_add_event_cb(panel, event_multiplayer_open_menu, LV_EVENT_LONG_PRESSED, (void *)(intptr_t)p);
         mp_state.panels[i] = panel;
@@ -593,6 +794,14 @@ void rebuild_multiplayer_layout(int track)
         create_counter_row(panel, COUNTER_TYPE_EXPERIENCE,
             &mp_state.counter_rows[i][COUNTER_TYPE_EXPERIENCE],
             &mp_state.counter_values[i][COUNTER_TYPE_EXPERIENCE], p);
+    }
+
+    if (layout->panel_count > 0 && spec_is_wedge(&layout->panels[0])) {
+        /* Transparent overlay that draws the separator lines between
+           slices (LV_USE_LINE is disabled, so draw them directly). */
+        lv_obj_t *sep = make_plain_box(screen_multiplayer, 360, 360);
+        lv_obj_set_pos(sep, 0, 0);
+        lv_obj_add_event_cb(sep, event_wedge_separators, LV_EVENT_DRAW_MAIN, NULL);
     }
 
     mp_battery_icon = add_low_battery_icon(screen_multiplayer);

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -413,17 +413,17 @@ static lv_color_t refresh_mp_panel(lv_obj_t *panel, lv_obj_t *life_lbl, lv_obj_t
         text_color = color_is_light(bg_color) ? lv_color_black() : lv_color_white();
     }
 
-    if (panel != NULL) {
-        lv_obj_set_style_bg_color(panel, bg_color, 0);
-        lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, 0);
-    }
-
     if (player_eliminated[i]) {
         bg_color = lv_color_hex(0x404040);
         text_color = lv_color_hex(0x808080);
-        if (panel != NULL) {
-            lv_obj_set_style_bg_color(panel, bg_color, 0);
-        }
+    }
+
+    /* Only write the color when it actually changed: every style write
+       invalidates the whole panel, which on full-screen wedge panels means
+       a full-screen redraw. (bg_opa is set once at build time.) */
+    if (panel != NULL &&
+        lv_obj_get_style_bg_color(panel, LV_PART_MAIN).full != bg_color.full) {
+        lv_obj_set_style_bg_color(panel, bg_color, 0);
     }
 
     if (life_lbl != NULL) {

--- a/knobby/src/ui_mp.h
+++ b/knobby/src/ui_mp.h
@@ -12,7 +12,6 @@ void rebuild_multiplayer_layout(int track);
 
 void refresh_multiplayer_ui(void);
 
-void open_multiplayer_screen(void);
 void select_kick_timer(void);
 
 #endif // _UI_MP_H

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -214,6 +214,8 @@ static void event_menu_color(lv_event_t *e) {
 
 static void event_color_default(lv_event_t *e) {
   (void)e;
+  if (menu_player < 0 || menu_player >= MAX_DISPLAY_PLAYERS)
+    return;
   player_has_override[menu_player] = false;
   player_life_color[menu_player] = false;
   refresh_player_ui();
@@ -222,6 +224,8 @@ static void event_color_default(lv_event_t *e) {
 
 static void event_color_life(lv_event_t *e) {
   (void)e;
+  if (menu_player < 0 || menu_player >= MAX_DISPLAY_PLAYERS)
+    return;
   player_has_override[menu_player] = true;
   player_life_color[menu_player] = true;
   refresh_player_ui();
@@ -231,6 +235,8 @@ static void event_color_life(lv_event_t *e) {
 static void event_color_custom(lv_event_t *e) {
   char title_buf[32];
   (void)e;
+  if (menu_player < 0 || menu_player >= MAX_DISPLAY_PLAYERS)
+    return;
   color_picker_index = player_color_index[menu_player];
   if (color_picker_title_label != NULL) {
     snprintf(title_buf, sizeof(title_buf), "%s\nColor",
@@ -264,6 +270,8 @@ void change_player_color(int delta) {
 }
 
 void commit_player_color(void) {
+  if (menu_player < 0 || menu_player >= MAX_DISPLAY_PLAYERS)
+    return;
   player_has_override[menu_player] = true;
   player_color_index[menu_player] = color_picker_index;
   player_life_color[menu_player] = false;

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -181,8 +181,7 @@ static void event_all_damage_apply(lv_event_t *e) {
     if (i == menu_player && !include_myself) {
       continue;
     }
-    damage_log_add(i, -all_damage_value, LOG_EVT_LIFE, -1);
-    player_life[i] = clamp_life(player_life[i] - all_damage_value);
+    apply_life_delta(i, -all_damage_value);
   }
 
   refresh_player_ui();

--- a/knobby/src/ui_player_menu.c
+++ b/knobby/src/ui_player_menu.c
@@ -333,7 +333,7 @@ void build_counter_menu_screen(void) {
       event_counter_poison,
       event_counter_experience,
   };
-  quad_item_t items[4];
+  quad_item_t items[4] = {{0}};
 
   for (i = 0; i < 4; i++) {
     const counter_definition_t *def = get_counter_definition(types[i]);

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -29,7 +29,7 @@ endif
 CFLAGS    := -Wall -Wno-unused-function \
              -DLV_CONF_INCLUDE_SIMPLE -DSIMULATOR=1 \
              -I. -Iesp_stubs -I$(LVGL_PATH) -I$(LVGL_PATH)/src -I$(KNOBBY) -I$(KNOBBY)/src \
-             -O2 -g
+             -O2 -g -MMD -MP
 
 LDFLAGS   := -lm
 
@@ -40,7 +40,7 @@ GUI_LDFLAGS := $(SDL_LDFLAGS) $(LDFLAGS)
 # ---- Source files ----
 
 # Top-level knobby files
-KNOBBY_TOP_SRCS := $(KNOBBY)/knob.c
+KNOBBY_TOP_SRCS := $(KNOBBY)/knob.c $(KNOBBY)/board_pins.c
 
 # Source files in src/
 KNOBBY_SRC_SRCS := $(addprefix $(KNOBBY)/src/, \
@@ -118,3 +118,6 @@ GUI_ONLY_SRCS := $(filter-out $(ALL_SRCS),$(ALL_SRCS_GUI))
 
 $(foreach src,$(ALL_SRCS),$(eval $(call compile_rule,$(src))))
 $(foreach src,$(GUI_ONLY_SRCS),$(eval $(call gui_compile_rule,$(src))))
+
+# Auto-generated header dependencies (-MMD)
+-include $(wildcard $(BUILD)/*.d)

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -250,6 +250,11 @@ for ae in 0 1; do
     shot "setting_autoelim_${ae_name[$ae]}.png" --screen setting:auto-eliminate --auto-eliminate "$ae"
 done
 
+for rf in 0 1; do
+    rf_name=("off" "on")
+    shot "setting_randomfirst_${rf_name[$rf]}.png" --screen setting:random-first --random-first "$rf"
+done
+
 # All settings pages in their default state (count derived from the sim)
 NPAGES=$($SIM --print-settings-pages)
 for p in $(seq 1 "$NPAGES"); do

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -289,8 +289,9 @@ shot "all_damage_random.png" --screen all-damage \
 # ============================================================
 # 15. Player-menu for random player
 # ============================================================
-shot "player_menu_p$((RANDOM % 4)).png" --screen player-menu \
-    --menu-player $((RANDOM % 4))
+mp=$((RANDOM % 4))
+shot "player_menu_p${mp}.png" --screen player-menu \
+    --menu-player "$mp"
 
 # ============================================================
 # 16. Battery at random legal voltage
@@ -316,7 +317,8 @@ done
 # ============================================================
 # 17. Dice with a result
 # ============================================================
-shot "dice_$((RANDOM % 20 + 1)).png" --screen dice --dice $((RANDOM % 20 + 1))
+d=$((RANDOM % 20 + 1))
+shot "dice_${d}.png" --screen dice --dice "$d"
 
 # ============================================================
 # 18. Event log with random data
@@ -339,7 +341,17 @@ shot "1p_timer_preview_p444.png" --screen 1p --track 1 \
     --random-counters
 
 # ============================================================
-# 20. Intro screen
+# 20. Menus, rename, counters-menu (previously uncovered)
+# ============================================================
+shot "menu_main.png" --screen menu
+shot "menu_tools.png" --screen tools
+shot "counters_menu.png" --screen counters-menu
+shot "rename.png" --screen rename
+shot "rename_longnames.png" --screen rename \
+    --names "Maximilian,Bartholomew,Christopher,Evangelina"
+
+# ============================================================
+# 21. Intro screen
 # ============================================================
 shot "intro.png" --screen intro
 

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -221,31 +221,39 @@ shot "color_menu.png" --screen color-menu --menu-player 0
 shot "color_picker.png" --screen color-picker --menu-player 0
 
 # ============================================================
-# 15. Settings pages with different toggle states
+# 15. Settings: every toggle in every state, page-agnostic.
+# "setting:<id>" makes the sim find whichever page hosts the item,
+# so this section never changes when settings move between pages.
 # ============================================================
 for dim in 0 1 2 3; do
     dim_name=("off" "15s" "30s" "60s")
-    shot "settings_menu_dim_${dim_name[$dim]}.png" --screen settings-menu --auto-dim "$dim"
+    shot "setting_autodim_${dim_name[$dim]}.png" --screen setting:autodim --auto-dim "$dim"
 done
 
 for cm in 0 1; do
     cm_name=("player" "life")
-    shot "settings_more_cm${cm_name[$cm]}.png" --screen settings-more --color-mode "$cm"
+    shot "setting_colormode_${cm_name[$cm]}.png" --screen setting:color-mode --color-mode "$cm"
 done
 
 for dt in 0 1 2 3; do
     dt_name=("never" "5s" "15s" "30s")
-    shot "settings_more_ds${dt_name[$dt]}.png" --screen settings-more --deselect "$dt"
+    shot "setting_deselect_${dt_name[$dt]}.png" --screen setting:deselect --deselect "$dt"
 done
 
 for rot in 0 1 2; do
     rot_name=("absolute" "centric" "tabletop")
-    shot "settings_more_orient_${rot_name[$rot]}.png" --screen settings-more --orientation "$rot"
+    shot "setting_orientation_${rot_name[$rot]}.png" --screen setting:orientation --orientation "$rot"
 done
 
 for ae in 0 1; do
-    ae_name=("aeoff" "aeon")
-    shot "settings_more_${ae_name[$ae]}.png" --screen settings-more --auto-eliminate "$ae"
+    ae_name=("off" "on")
+    shot "setting_autoelim_${ae_name[$ae]}.png" --screen setting:auto-eliminate --auto-eliminate "$ae"
+done
+
+# All settings pages in their default state (count derived from the sim)
+NPAGES=$($SIM --print-settings-pages)
+for p in $(seq 1 "$NPAGES"); do
+    shot "settings_page${p}.png" --screen "settings-page${p}"
 done
 
 # ============================================================
@@ -393,7 +401,7 @@ for f in "${FILES[@]}"; do
         brightness_*)         SEC_BRIGHT+=("$f") ;;
         counter_edit_*)       SEC_COUNTER_EDIT+=("$f") ;;
         damage_*|select_*|all_damage_*) SEC_DAMAGE+=("$f") ;;
-        settings_*)           SEC_SETTINGS+=("$f") ;;
+        settings_*|setting_*) SEC_SETTINGS+=("$f") ;;
         mana_*)               SEC_MANA+=("$f") ;;
         *)                    SEC_OTHER+=("$f") ;;
     esac

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -3,7 +3,7 @@
 # Run from the sim/ directory: ./generate_matrix.sh
 set -e
 
-SIM=./knobby_sim
+SIM="${SIM:-./knobby_sim}"
 OUT=screenshots
 COUNT=0
 FILES=()
@@ -121,6 +121,19 @@ for track in 2 3 4; do
             --selected "$player"
     done
 done
+
+# ============================================================
+# 5b. Multi-select — multiple players selected together (knob hits all)
+# ============================================================
+shot "multiselect_2p_01.png"  --screen 2p --track 2 --multi-select 1 --selected-players 0,1
+shot "multiselect_3p_02.png"  --screen 3p --track 3 --multi-select 1 --selected-players 0,2
+shot "multiselect_4p_02.png"  --screen 4p --track 4 --multi-select 1 --selected-players 0,2
+shot "multiselect_4p_013.png" --screen 4p --track 4 --multi-select 1 --selected-players 0,1,3
+# Shared-delta preview across the selected set (damage and heal)
+shot "multiselect_4p_preview_neg.png" --screen 4p --track 4 --multi-select 1 \
+    --selected-players 0,1,2 --preview-delta -3 --life 20,30,40,15
+shot "multiselect_3p_preview_pos.png" --screen 3p --track 3 --multi-select 1 \
+    --selected-players 0,1,2 --preview-delta 5 --life 20,30,40
 
 # ============================================================
 # 6. Random counters — multiplayer × orientations + 1p
@@ -245,6 +258,7 @@ for rot in 0 1 2; do
     shot "setting_orientation_${rot_name[$rot]}.png" --screen setting:orientation --orientation "$rot"
 done
 
+# Settings page 3 (gameplay toggles: auto-eliminate + multi-select)
 for ae in 0 1; do
     ae_name=("off" "on")
     shot "setting_autoelim_${ae_name[$ae]}.png" --screen setting:auto-eliminate --auto-eliminate "$ae"
@@ -253,6 +267,11 @@ done
 for rf in 0 1; do
     rf_name=("off" "on")
     shot "setting_randomfirst_${rf_name[$rf]}.png" --screen setting:random-first --random-first "$rf"
+done
+
+for ms in 0 1; do
+    ms_name=("off" "on")
+    shot "setting_multiselect_${ms_name[$ms]}.png" --screen setting:multi-select --multi-select "$ms"
 done
 
 # All settings pages in their default state (count derived from the sim)
@@ -383,7 +402,7 @@ write_section() {
 
 # Sort files into sections
 SEC_1P_PREV=(); SEC_2P_PREV=(); SEC_3P_PREV=(); SEC_4P_PREV=()
-SEC_LIFE=(); SEC_LIFECOLOR=(); SEC_PERPLAYER=(); SEC_SELECTED=(); SEC_COUNTERS=()
+SEC_LIFE=(); SEC_LIFECOLOR=(); SEC_PERPLAYER=(); SEC_SELECTED=(); SEC_MULTISEL=(); SEC_COUNTERS=()
 SEC_BRIGHT=(); SEC_COUNTER_EDIT=(); SEC_DAMAGE=(); SEC_SETTINGS=()
 SEC_TIMER=()
 SEC_MANA=()
@@ -392,6 +411,7 @@ SEC_OTHER=()
 
 for f in "${FILES[@]}"; do
     case "$f" in
+        multiselect_*)        SEC_MULTISEL+=("$f") ;;
         lowbatt_*)            SEC_LOWBATT+=("$f") ;;
         1p_preview_*)         SEC_1P_PREV+=("$f") ;;
         2p_*_preview_*)       SEC_2P_PREV+=("$f") ;;
@@ -421,6 +441,7 @@ write_section "Life Totals (Player Colors)" "${SEC_LIFE[@]}"
 write_section "Life Totals (Life Colors)" "${SEC_LIFECOLOR[@]}"
 write_section "Life Totals (Per-Player Colors)" "${SEC_PERPLAYER[@]}"
 write_section "Selected Player" "${SEC_SELECTED[@]}"
+write_section "Multi-Select" "${SEC_MULTISEL[@]}"
 write_section "Player Counters" "${SEC_COUNTERS[@]}"
 write_section "Brightness" "${SEC_BRIGHT[@]}"
 write_section "Counter Edit" "${SEC_COUNTER_EDIT[@]}"

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -304,22 +304,7 @@ static void populate_random_counters(void)
             player_counters[p][t] = rand() % 100;
 }
 
-static void populate_random_log(void)
-{
-    int i;
-    const uint8_t event_types[] = {LOG_EVT_LIFE, LOG_EVT_CMD_DAMAGE, LOG_EVT_COUNTER};
-    for (i = 0; i < 15; i++) {
-        int player = rand() % 4;
-        int delta = (rand() % 20) - 10;
-        uint8_t evt = event_types[rand() % 3];
-        int source = -1;
-        if (delta == 0) delta = 1;
-        if (evt == LOG_EVT_CMD_DAMAGE) source = (player + 1) % 4;
-        else if (evt == LOG_EVT_COUNTER) { source = rand() % COUNTER_TYPE_COUNT; if (delta < 0) delta = -delta; }
-        sim_tick_advance(5000 + (uint32_t)(rand() % 30000));
-        damage_log_add(player, delta, evt, source);
-    }
-}
+/* random-log fixture lives in sim_stubs.c (shared with the SDL sim) */
 
 /* ---- Main ---- */
 int main(int argc, char *argv[])
@@ -567,7 +552,7 @@ int main(int argc, char *argv[])
         if (do_random_counters) \
             populate_random_counters(); \
         if (do_random_log) { \
-            populate_random_log(); \
+            sim_populate_random_log(); \
             open_damage_log_screen(); \
         } \
         if (turn_number_set) { \

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -233,6 +233,7 @@ static void print_usage(void)
            "  --auto-dim <n>         0=OFF, 1=15s, 2=30s, 3=60s (default: 0)\n"
            "  --deselect <n>         0=never, 1=5s, 2=15s, 3=30s (default: 0)\n"
            "  --auto-eliminate <n>   0=OFF, 1=ON (default: 1)\n"
+           "  --random-first <n>     0=OFF, 1=ON random first-player pick on reset (default: 1)\n"
            "\nSpecial state:\n"
            "  --dice <n>             Set dice roll result (1-20)\n"
            "  --counter-type <n>     Counter type for counter-edit: 0=cmd tax, 1=partner tax,\n"
@@ -390,6 +391,8 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[i], "--selected") == 0 && i + 1 < argc) {
             selected_val = atoi(argv[++i]);
             selected_set = 1;
+        } else if (strcmp(argv[i], "--random-first") == 0 && i + 1 < argc) {
+            sim_nvs_preset_i8("rand_first", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--preview-delta") == 0 && i + 1 < argc) {
             preview_delta = atoi(argv[++i]);
             preview_delta_set = 1;

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -45,10 +45,11 @@ static void sim_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *
     lv_disp_flush_ready(drv);
 }
 
-static void save_screenshot_png(const char *filename)
+static int save_screenshot_png(const char *filename)
 {
+    int ok = 1;
     uint8_t *rgb = malloc(SCREEN_W * SCREEN_H * 3);
-    if (!rgb) { fprintf(stderr, "Failed to allocate RGB buffer\n"); return; }
+    if (!rgb) { fprintf(stderr, "Failed to allocate RGB buffer\n"); return 0; }
 
     {
         const int cx = SCREEN_W / 2;
@@ -78,10 +79,12 @@ static void save_screenshot_png(const char *filename)
 
     if (!stbi_write_png(filename, SCREEN_W, SCREEN_H, 3, rgb, SCREEN_W * 3)) {
         fprintf(stderr, "Failed to write %s\n", filename);
+        ok = 0;
     } else {
         printf("Saved: %s\n", filename);
     }
     free(rgb);
+    return ok;
 }
 
 static void render_frame(void)
@@ -214,7 +217,7 @@ static void print_usage(void)
            "  --life <p1,p2,...>     Set player life totals (default: starting-life for all)\n"
            "  --names <p1,p2,...>    Set player names (default: P1..P8)\n"
            "  --players <n>          Number of players in the game, 1-8 (default: 4)\n"
-           "  --track <n>            Players shown on screen, 1-4 (default: 4)\n"
+           "  --track <n>            Players shown on screen, 1-4 (default: 1)\n"
            "  --starting-life <n>    Starting/max life total (default: 40)\n"
            "  --selected <n>         Which player is selected, -1=none (default: -1)\n"
            "  --selected-players <csv> Players selected together, e.g. 0,2 (multi-select set)\n"
@@ -264,7 +267,7 @@ static void print_usage(void)
 }
 
 /* ---- CSV helpers ---- */
-static void parse_csv_ints(const char *csv, int *out, int max_count)
+static int parse_csv_ints(const char *csv, int *out, int max_count)
 {
     char buf[256];
     char *tok;
@@ -275,6 +278,7 @@ static void parse_csv_ints(const char *csv, int *out, int max_count)
         out[i++] = atoi(tok);
         tok = strtok(NULL, ",");
     }
+    return i;
 }
 
 static void parse_csv_strings(const char *csv, char names[][16], int max_count)
@@ -309,6 +313,7 @@ int main(int argc, char *argv[])
     const char *outdir = "screenshots";
     const char *output_filename = NULL;
     int life_values[MAX_DISPLAY_PLAYERS] = {0};
+    int life_count = 0;
     int life_set = 0;
     char name_values[MAX_GAME_PLAYERS][16] = {{0}};
     int names_set = 0;
@@ -362,7 +367,7 @@ int main(int argc, char *argv[])
         } else if (strcmp(argv[i], "--print-settings-pages") == 0) {
             print_settings_pages = 1;
         } else if (strcmp(argv[i], "--life") == 0 && i + 1 < argc) {
-            parse_csv_ints(argv[++i], life_values, MAX_DISPLAY_PLAYERS);
+            life_count = parse_csv_ints(argv[++i], life_values, MAX_DISPLAY_PLAYERS);
             life_set = 1;
         } else if (strcmp(argv[i], "--names") == 0 && i + 1 < argc) {
             parse_csv_strings(argv[++i], name_values, MAX_GAME_PLAYERS);
@@ -483,7 +488,9 @@ int main(int argc, char *argv[])
     /* Apply RAM-only overrides after navigation */
     #define APPLY_RAM_OVERRIDES() do { \
         if (life_set) { \
-            for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) \
+            /* only override the players the CSV named; a short CSV must \
+               not zero (and auto-eliminate) the rest */ \
+            for (i = 0; i < life_count && i < MAX_DISPLAY_PLAYERS; i++) \
                 player_life[i] = life_values[i]; \
         } \
         if (names_set) { \
@@ -615,7 +622,8 @@ int main(int argc, char *argv[])
             snprintf(path, sizeof(path), "%s/%s", outdir, output_filename);
         else
             snprintf(path, sizeof(path), "%s/%s.png", outdir, screen_name);
-        save_screenshot_png(path);
+        if (!save_screenshot_png(path))
+            return 1;
     }
 
     return 0;

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -115,10 +115,9 @@ static void nav_4p(void)         { nvs_set_players_to_track(4); reset_all_values
 static void nav_intro(void)      { lv_scr_load(screen_intro); }
 static void nav_menu(void)       { open_quad_menu(); }
 static void nav_tools(void)      { lv_scr_load(screen_tools_menu); }
-static void nav_settings_menu(void) { lv_scr_load(screen_screen_settings_menu); }
-static void nav_settings_more(void) { lv_scr_load(screen_settings_page2); }
+static void nav_settings_menu(void) { lv_scr_load(settings_pages[0]); }
 static void nav_brightness(void) { open_settings_screen(); }
-static void nav_battery(void)    { update_battery_measurement(true); refresh_battery_ui(); lv_scr_load(screen_battery); }
+static void nav_battery(void)    { open_battery_screen(); }
 static void nav_dice(void)       { open_dice_screen(); }
 static void nav_damage_log(void) { open_damage_log_screen(); }
 static void nav_game_mode(void)  { open_game_mode_menu(); }
@@ -160,7 +159,6 @@ static const screen_entry_t all_screens[] = {
     {"menu",          nav_menu},
     {"tools",         nav_tools},
     {"settings-menu", nav_settings_menu},
-    {"settings-more", nav_settings_more},
     {"brightness",    nav_brightness},
     {"battery",       nav_battery},
     {"dice",          nav_dice},
@@ -179,6 +177,33 @@ static const screen_entry_t all_screens[] = {
     {"mana",          nav_mana},
     {NULL, NULL}
 };
+
+/* Settings screens resolved dynamically from the declarative table:
+   "settings-page<N>" (1-based) and "setting:<id>" (page hosting that item).
+   Returns 1 if it navigated, 0 if the name is not a settings form. */
+static int nav_dynamic_settings(const char *name)
+{
+    if (strncmp(name, "settings-page", 13) == 0) {
+        int p = atoi(name + 13);
+        if (p < 1 || p > settings_page_count) {
+            fprintf(stderr, "Settings page out of range: %s (pages: 1-%d)\n",
+                    name, settings_page_count);
+            exit(1);
+        }
+        lv_scr_load(settings_pages[p - 1]);
+        return 1;
+    }
+    if (strncmp(name, "setting:", 8) == 0) {
+        int p = settings_item_page(name + 8);
+        if (p < 0) {
+            fprintf(stderr, "Unknown setting id: %s\n", name + 8);
+            exit(1);
+        }
+        lv_scr_load(settings_pages[p]);
+        return 1;
+    }
+    return 0;
+}
 
 /* ---- Usage ---- */
 static void print_usage(void)
@@ -229,10 +254,14 @@ static void print_usage(void)
            "  --turn-elapsed <ms>    Elapsed game time in milliseconds\n"
            "\n  --help, -h             Show this message\n"
            "\nAvailable screens:\n"
-           "  main 1p 2p 3p 4p intro menu tools settings-menu settings-more\n"
+           "  main 1p 2p 3p 4p intro menu tools settings-menu\n"
+           "  settings-page<N>       Settings page N (1-based)\n"
+           "  setting:<id>           Page hosting a setting (e.g. setting:autodim)\n"
            "  brightness battery dice damage-log game-mode custom-life select\n"
            "  damage player-menu rename all-damage counters-menu counter-edit\n"
-           "  color-menu color-picker mana\n");
+           "  color-menu color-picker mana\n"
+           "\nIntrospection:\n"
+           "  --print-settings-pages Print the number of settings pages and exit\n");
 }
 
 /* ---- CSV helpers ---- */
@@ -339,9 +368,13 @@ int main(int argc, char *argv[])
 
     srand((unsigned int)time(NULL));
 
+    int print_settings_pages = 0;
+
     for (i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--screen") == 0 && i + 1 < argc) {
             screen_name = argv[++i];
+        } else if (strcmp(argv[i], "--print-settings-pages") == 0) {
+            print_settings_pages = 1;
         } else if (strcmp(argv[i], "--life") == 0 && i + 1 < argc) {
             parse_csv_ints(argv[++i], life_values, MAX_DISPLAY_PLAYERS);
             life_set = 1;
@@ -449,6 +482,11 @@ int main(int argc, char *argv[])
 
     knob_gui();
 
+    if (print_settings_pages) {
+        printf("%d\n", settings_page_count);
+        return 0;
+    }
+
     /* Apply RAM-only overrides after navigation */
     #define APPLY_RAM_OVERRIDES() do { \
         if (life_set) { \
@@ -544,20 +582,16 @@ int main(int argc, char *argv[])
 
     {
         const screen_entry_t *entry;
-        int found = 0;
-        for (entry = all_screens; entry->name != NULL; entry++) {
-            if (strcmp(entry->name, screen_name) == 0) {
-                char path[512];
-                entry->navigate();
-                APPLY_RAM_OVERRIDES();
-                render_frame();
-                if (output_filename)
-                    snprintf(path, sizeof(path), "%s/%s", outdir, output_filename);
-                else
-                    snprintf(path, sizeof(path), "%s/%s.png", outdir, screen_name);
-                save_screenshot_png(path);
-                found = 1;
-                break;
+        char path[512];
+        int found = nav_dynamic_settings(screen_name);
+
+        if (!found) {
+            for (entry = all_screens; entry->name != NULL; entry++) {
+                if (strcmp(entry->name, screen_name) == 0) {
+                    entry->navigate();
+                    found = 1;
+                    break;
+                }
             }
         }
         if (!found) {
@@ -565,6 +599,13 @@ int main(int argc, char *argv[])
             print_usage();
             return 1;
         }
+        APPLY_RAM_OVERRIDES();
+        render_frame();
+        if (output_filename)
+            snprintf(path, sizeof(path), "%s/%s", outdir, output_filename);
+        else
+            snprintf(path, sizeof(path), "%s/%s.png", outdir, screen_name);
+        save_screenshot_png(path);
     }
 
     return 0;

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -28,10 +28,6 @@
 #define SCREEN_W 360
 #define SCREEN_H 360
 
-/* Globals normally defined in scr_st77916.h */
-lv_indev_t *indev_knob = NULL;
-int encoder_cont = 0;
-
 /* ---- Framebuffer ---- */
 static lv_color_t framebuffer[SCREEN_W * SCREEN_H];
 static lv_color_t draw_buf_data[SCREEN_W * 72];

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -221,6 +221,7 @@ static void print_usage(void)
            "  --track <n>            Players shown on screen, 1-4 (default: 4)\n"
            "  --starting-life <n>    Starting/max life total (default: 40)\n"
            "  --selected <n>         Which player is selected, -1=none (default: -1)\n"
+           "  --selected-players <csv> Players selected together, e.g. 0,2 (multi-select set)\n"
            "\nLife preview (shows pending delta before commit):\n"
            "  --preview-delta <n>    Pending life change to display (e.g. +12, -5)\n"
            "  --preview-player <n>   Which player shows the preview, -1=1p mode (default: -1)\n"
@@ -234,6 +235,7 @@ static void print_usage(void)
            "  --deselect <n>         0=never, 1=5s, 2=15s, 3=30s (default: 0)\n"
            "  --auto-eliminate <n>   0=OFF, 1=ON (default: 1)\n"
            "  --random-first <n>     0=OFF, 1=ON random first-player pick on reset (default: 1)\n"
+           "  --multi-select <n>     0=OFF, 1=ON (default: 0)\n"
            "\nSpecial state:\n"
            "  --dice <n>             Set dice roll result (1-20)\n"
            "  --counter-type <n>     Counter type for counter-edit: 0=cmd tax, 1=partner tax,\n"
@@ -331,6 +333,8 @@ int main(int argc, char *argv[])
     int names_set = 0;
     int selected_val = -1;
     int selected_set = 0;
+    int selected_players_values[MAX_DISPLAY_PLAYERS] = {-1, -1, -1, -1};
+    int selected_players_set = 0;
     int preview_delta = 0;
     int preview_delta_set = 0;
     int arg_preview_player = -1;
@@ -393,6 +397,11 @@ int main(int argc, char *argv[])
             selected_set = 1;
         } else if (strcmp(argv[i], "--random-first") == 0 && i + 1 < argc) {
             sim_nvs_preset_i8("rand_first", (int8_t)atoi(argv[++i]));
+        } else if (strcmp(argv[i], "--selected-players") == 0 && i + 1 < argc) {
+            parse_csv_ints(argv[++i], selected_players_values, MAX_DISPLAY_PLAYERS);
+            selected_players_set = 1;
+        } else if (strcmp(argv[i], "--multi-select") == 0 && i + 1 < argc) {
+            sim_nvs_preset_i8("multi_sel", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--preview-delta") == 0 && i + 1 < argc) {
             preview_delta = atoi(argv[++i]);
             preview_delta_set = 1;
@@ -502,14 +511,24 @@ int main(int argc, char *argv[])
                     snprintf(player_names[i], sizeof(player_names[i]), "%s", name_values[i]); \
             } \
         } \
-        if (selected_set) \
-            selected_player = selected_val; \
+        if (selected_players_set) { \
+            int j; \
+            selection_clear(); \
+            for (j = 0; j < MAX_DISPLAY_PLAYERS; j++) { \
+                int p = selected_players_values[j]; \
+                if (p >= 0 && p < MAX_DISPLAY_PLAYERS) \
+                    player_selected[p] = true; \
+            } \
+        } else if (selected_set) { \
+            selection_set_single(selected_val); \
+        } \
         if (preview_delta_set) { \
-            if (arg_preview_player < 0) arg_preview_player = 0; \
-            preview_player = arg_preview_player; \
+            if (!selected_players_set && !selected_set) { \
+                if (arg_preview_player < 0) arg_preview_player = 0; \
+                selection_set_single(arg_preview_player); \
+            } \
             pending_life_delta = preview_delta; \
             life_preview_active = true; \
-            selected_player = arg_preview_player; \
         } \
         if (brightness_set) { \
             brightness_percent = brightness_val; \
@@ -602,6 +621,13 @@ int main(int argc, char *argv[])
             print_usage();
             return 1;
         }
+        /* reset_all_values() (called by the nav_* helpers) kicks off the
+           "pick first player" roulette animation, whose timer would keep
+           reassigning the selection while render_frame() advances time.
+           Stop it and clear the resulting selection so screenshots are
+           deterministic; APPLY_RAM_OVERRIDES then sets any requested state. */
+        stop_player_selection_animation();
+        selection_clear();
         APPLY_RAM_OVERRIDES();
         render_frame();
         if (output_filename)

--- a/sim/sim_sdl2.c
+++ b/sim/sim_sdl2.c
@@ -179,7 +179,6 @@ int main(int argc, char *argv[])
 static void handle_sdl_events(void)
 {
     SDL_Event event;
-    static int encoder_cont = 0;
 
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_QUIT) {
@@ -188,19 +187,15 @@ static void handle_sdl_events(void)
             // Handled by sdl_mouse_read
         } else if (event.type == SDL_MOUSEWHEEL) {
             if (event.wheel.y > 0) {
-                encoder_cont++;
-                knob_change(KNOB_RIGHT, encoder_cont);
+                knob_change(KNOB_RIGHT);
             } else if (event.wheel.y < 0) {
-                encoder_cont--;
-                knob_change(KNOB_LEFT, encoder_cont);
+                knob_change(KNOB_LEFT);
             }
         } else if (event.type == SDL_KEYDOWN) {
             if (event.key.keysym.sym == SDLK_RIGHT) {
-                encoder_cont++;
-                knob_change(KNOB_RIGHT, encoder_cont);
+                knob_change(KNOB_RIGHT);
             } else if (event.key.keysym.sym == SDLK_LEFT) {
-                encoder_cont--;
-                knob_change(KNOB_LEFT, encoder_cont);
+                knob_change(KNOB_LEFT);
             } else if (event.key.keysym.sym == SDLK_UP) {
                 knob_notify_swipe_up();
             } else if (event.key.keysym.sym == SDLK_DOWN) {

--- a/sim/sim_sdl2.c
+++ b/sim/sim_sdl2.c
@@ -107,9 +107,14 @@ int main(int argc, char *argv[])
 {
     extern float sim_battery_voltage;
     int i;
+    int do_random_log = 0;
     for (i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--battery-voltage") == 0 && i + 1 < argc) {
             sim_battery_voltage = (float)atof(argv[++i]);
+        } else if (strcmp(argv[i], "--random-log") == 0) {
+            do_random_log = 1;
+        } else {
+            fprintf(stderr, "GUI sim: ignoring unsupported option %s\n", argv[i]);
         }
     }
 
@@ -150,6 +155,7 @@ int main(int argc, char *argv[])
 
     // Set some defaults if needed
     nvs_set_players_to_track(4);
+    if (do_random_log) sim_populate_random_log();
     back_to_main();
 
     last_tick = SDL_GetTicks();

--- a/sim/sim_stubs.c
+++ b/sim/sim_stubs.c
@@ -27,27 +27,7 @@ void sim_tick_advance(uint32_t ms)
 
 /* ---- Board detection ---- */
 
-const board_pins_t board_k518 = {
-    .name       = "JC3636K518",
-    .tft_blk    = 47,  .tft_rst  = 21,  .tft_cs  = 14,  .tft_sck = 13,
-    .tft_sda0   = 15,  .tft_sda1 = 16,  .tft_sda2 = 17, .tft_sda3 = 18,
-    .touch_scl  = 12,  .touch_sda = 11, .touch_int = 9,  .touch_rst = 10,
-    .enc_a      = 8,   .enc_b    = 7,
-    .bat_adc    = 1,
-    .btn        = 0,
-    .mirror_x   = false, .mirror_y = false,
-};
-
-const board_pins_t board_k718 = {
-    .name       = "JC3636K718",
-    .tft_blk    = 21,  .tft_rst  = 17,  .tft_cs  = 12,  .tft_sck = 11,
-    .tft_sda0   = 13,  .tft_sda1 = 14,  .tft_sda2 = 15, .tft_sda3 = 16,
-    .touch_scl  = 10,  .touch_sda = 9,  .touch_int = 7,  .touch_rst = 8,
-    .enc_a      = 2,   .enc_b    = 1,
-    .bat_adc    = 6,
-    .btn        = 0,
-    .mirror_x   = true,  .mirror_y = true,
-};
+/* Pin tables come from knobby/board_pins.c (shared with firmware). */
 
 const board_pins_t *board = NULL;
 

--- a/sim/sim_stubs.c
+++ b/sim/sim_stubs.c
@@ -232,3 +232,28 @@ void scr_display_on(void) { /* no-op in simulator */ }
 /* ---- Random ---- */
 
 uint32_t esp_random(void) { return (uint32_t)rand(); }
+
+/* ---- Shared test fixtures ---- */
+
+/* Populate the event log with random entries (shared by the headless
+   and SDL mains so --random-log behaves the same in both). */
+#include "damage_log.h"
+#include "game.h"
+
+void sim_populate_random_log(void)
+{
+    int i;
+    const uint8_t event_types[] = {LOG_EVT_LIFE, LOG_EVT_CMD_DAMAGE, LOG_EVT_COUNTER};
+    /* > LOG_PAGE_SIZE (32) so screenshots exercise the paginated render */
+    for (i = 0; i < 40; i++) {
+        int player = rand() % 4;
+        int delta = (rand() % 20) - 10;
+        uint8_t evt = event_types[rand() % 3];
+        int source = -1;
+        if (delta == 0) delta = 1;
+        if (evt == LOG_EVT_CMD_DAMAGE) source = (player + 1) % 4;
+        else if (evt == LOG_EVT_COUNTER) { source = rand() % COUNTER_TYPE_COUNT; if (delta < 0) delta = -delta; }
+        sim_tick_advance(5000 + (uint32_t)(rand() % 30000));
+        damage_log_add(player, delta, evt, source);
+    }
+}

--- a/sim/sim_stubs.c
+++ b/sim/sim_stubs.c
@@ -203,7 +203,6 @@ knob_handle_t iot_knob_create(const knob_config_t *config)
     return (knob_handle_t)1; /* non-NULL dummy */
 }
 
-esp_err_t iot_knob_delete(knob_handle_t h) { (void)h; return ESP_OK; }
 esp_err_t iot_knob_register_cb(knob_handle_t h, knob_event_t e, knob_cb_t cb, void *d)
 {
     (void)h; (void)e; (void)cb; (void)d;

--- a/sim/sim_stubs.h
+++ b/sim/sim_stubs.h
@@ -7,6 +7,9 @@
 uint32_t sim_millis(void);
 void sim_tick_advance(uint32_t ms);
 
+/* Fill the event log with 40 random entries (--random-log fixture) */
+void sim_populate_random_log(void);
+
 /* Pre-populate the in-memory NVS store before knob_nvs_init() runs.
  * This lets CLI flags control settings that knob_nvs.c reads at init. */
 void sim_nvs_preset_i8(const char *key, int8_t value);


### PR DESCRIPTION
Three interlocking defects in how elimination, undo, and reset share state:

- Manual (conceded) elimination is now tracked separately from auto-elimination, so undoing an unrelated old log entry — which re-runs `check_player_elimination` — can no longer silently revive a player who manually conceded above 0 life.
- `knob_life_reset()` now resets the event log, clears `elimination_action[]`, and clears the manual-elimination flags, so a previous game's log entry or undo action can't carry into a fresh game. The log reset is centralized here, covering every reset path (quad Reset and game-mode Apply); the now-redundant call in `event_general_reset` is removed.
- Undoing an elimination from the eliminated-player menu now also drops the log entry that caused it (`damage_log_remove_last_for`), so the same event can't be undone a second time from the Event Log and double-apply its delta.

### Stack note
Final commit of the ordered series on top of #100. Diff collapses to `damage_log.*`/`game.c`/`settings.c` once the ancestors merge.

### Testing
- Simulator builds clean. Elimination/undo state-lifecycle logic, no widget-layout change — no matrix diff.
