### PR TITLE
Table Sync (Experimental): ESP-NOW game-state mirroring between devices

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Compile with arduino-cli
         run: |
-          arduino-cli compile --fqbn "esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio" --export-binaries knobby
+          arduino-cli compile --fqbn "esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio,PartitionScheme=custom" --export-binaries knobby
 
       - name: Prepare Web Site
         run: |

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -411,6 +411,7 @@ void knob_gui(void)
     build_mana_screen();
     build_settings_screen();
     build_battery_screen();
+    build_table_sync_screen();
     build_damage_log_screen();
     build_quad_menus();
     build_game_mode_menu_screen();

--- a/knobby/knobby.ino
+++ b/knobby/knobby.ino
@@ -10,6 +10,7 @@
 #include "hal/lv_hal.h"
 #include "knob.h"
 #include "src/hw.h"
+#include "knobby_net.h"
 
 static const float BATTERY_DIVIDER_RATIO = 2.0f;
 static const float BATTERY_CALIBRATION_SCALE = 1.0f;
@@ -98,6 +99,9 @@ void setup()
   scr_lvgl_init();
   knob_gui();
 
+  // Table Sync sessions are RAM-only: every boot starts with the radio
+  // fully deinitialized until the user starts or joins a game.
+
   // Keep RTC8M clock alive during light sleep so LEDC PWM (backlight) continues
   esp_sleep_pd_config(ESP_PD_DOMAIN_RTC8M, ESP_PD_OPTION_ON);
   gpio_sleep_sel_dis((gpio_num_t)TFT_BLK);
@@ -112,6 +116,10 @@ void setup()
 // Minimum idle interval before using light sleep.
 // Below this threshold we fall back to vTaskDelay to avoid sleep/wake overhead.
 #define ACTIVE_SLEEP_MIN_MS 10U
+
+// Longest idle delay while Table Sync is on, so queued remote packets are
+// applied promptly even when LVGL has no timer due for a while.
+#define NET_SYNC_IDLE_MAX_MS 20U
 
 // Detect active USB host by checking if the SOF frame counter is advancing.
 // USB hosts send Start-of-Frame every 1ms; a changing counter means plugged in.
@@ -129,9 +137,12 @@ void loop()
   uint32_t time_till_next;
 
   knob_process_pending();
+  knobby_net_process();
   time_till_next = lv_timer_handler();
 
-  if (time_till_next >= ACTIVE_SLEEP_MIN_MS && !usb_host_active()) {
+  // Light sleep powers down the modem and would drop ESP-NOW packets, so
+  // Table Sync keeps the CPU on capped vTaskDelay idles instead.
+  if (time_till_next >= ACTIVE_SLEEP_MIN_MS && !usb_host_active() && !knobby_net_active()) {
     uint8_t level_a = gpio_get_level((gpio_num_t)ROTARY_ENC_PIN_A);
     uint8_t level_b = gpio_get_level((gpio_num_t)ROTARY_ENC_PIN_B);
     gpio_wakeup_enable((gpio_num_t)ROTARY_ENC_PIN_A, level_a ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
@@ -143,6 +154,8 @@ void loop()
   } else {
     gpio_wakeup_disable((gpio_num_t)ROTARY_ENC_PIN_A);
     gpio_wakeup_disable((gpio_num_t)ROTARY_ENC_PIN_B);
+    if (knobby_net_active() && time_till_next > NET_SYNC_IDLE_MAX_MS)
+      time_till_next = NET_SYNC_IDLE_MAX_MS;
     vTaskDelay(pdMS_TO_TICKS(time_till_next));
   }
 }

--- a/knobby/knobby_net.cpp
+++ b/knobby/knobby_net.cpp
@@ -1,0 +1,342 @@
+/* Table Sync: broadcasts full game-state snapshots over ESP-NOW and
+   mirrors snapshots from other Knobby devices in the same game session.
+   Convergence rules (game epoch, per-player Lamport versions, MAC
+   tiebreak) live in game.c; this file is the transport and the pairing
+   state machine. Based on a prototype by kbratos.
+
+   The session lives in RAM only — a reboot always comes up with the
+   radio off. Deliberate: a persisted session would re-enable the radio
+   (and disable light sleep) on every boot until the user found Leave,
+   and would re-add the radio's load right after the low-battery boot
+   gate passed on a rested cell. A device that reboots mid-game rejoins
+   via Invite/Join instead.
+
+   The ESP-NOW receive callback runs on the WiFi task, so packets are
+   queued here and drained from loop() via knobby_net_process() — game
+   state and LVGL must only be touched from the main task. */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <esp_now.h>
+#include <esp_wifi.h>
+
+#include "knobby_net.h"
+
+extern "C" {
+#include "src/net_sync.h"
+}
+
+#define KNOBBY_NET_MAGIC   0x4B4E4259u /* "KNBY": filters foreign ESP-NOW traffic */
+/* Protocol version: an identifier, not a counter — receivers check
+   strict equality and drop everything else, so bump it on ANY breaking
+   wire-format change. 0 is invalid (an all-zero packet must never
+   pass); 255 is reserved as an escape hatch ("extended version follows
+   the prelude") should the space ever run out. */
+#define KNOBBY_NET_VERSION 1
+/* A state snapshot doubles as repair: a slow beacon re-broadcasts it so
+   lost packets and rejoining devices converge without an ack layer. */
+#define KNOBBY_NET_BEACON_MS 5000UL
+/* Start Game / Invite broadcasts invites for this long; Join Game
+   listens for as long before giving up. */
+#define KNOBBY_NET_PAIR_WINDOW_MS 30000UL
+#define KNOBBY_NET_INVITE_PERIOD_MS 1000UL
+
+enum { KNOBBY_PKT_STATE = 0, KNOBBY_PKT_INVITE = 1, KNOBBY_PKT_NAMES = 2 };
+
+typedef union {
+  net_sync_state_t state;
+  net_sync_names_t names;
+} knobby_net_body_t;
+
+typedef struct __attribute__((packed)) {
+  /* ---- FROZEN PRELUDE ----------------------------------------------
+     The first 6 bytes are an eternal contract shared by every protocol
+     version, past and future: magic, version, type — in this order, at
+     these offsets, forever. This is what lets any firmware recognize a
+     packet from any other version well enough to know it can't speak
+     it, instead of parsing another layout as game state. Never
+     reorder, resize, or insert before these fields; evolve the
+     protocol only below this line (and bump KNOBBY_NET_VERSION). */
+  uint32_t magic;
+  uint8_t  version;
+  uint8_t  type;
+  /* ---- v1 layout — may change freely in future versions ---- */
+  uint16_t reserved;
+  uint32_t session;
+  knobby_net_body_t body; /* per-type payload; INVITE has none */
+} knobby_net_packet_t;
+
+static_assert(offsetof(knobby_net_packet_t, magic) == 0 &&
+              offsetof(knobby_net_packet_t, version) == 4 &&
+              offsetof(knobby_net_packet_t, type) == 5,
+              "the 6-byte prelude is frozen across all protocol versions");
+
+#define KNOBBY_NET_HDR_LEN   offsetof(knobby_net_packet_t, body)
+#define KNOBBY_NET_STATE_LEN (KNOBBY_NET_HDR_LEN + sizeof(net_sync_state_t))
+#define KNOBBY_NET_NAMES_LEN (KNOBBY_NET_HDR_LEN + sizeof(net_sync_names_t))
+
+typedef struct {
+  uint8_t type;
+  uint8_t wins_ties;
+  uint32_t session;
+  knobby_net_body_t body;
+} knobby_net_rx_t;
+
+static const uint8_t broadcast_mac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+static QueueHandle_t rx_queue = NULL;
+static uint8_t my_mac[6] = {0};
+static uint32_t last_tx_ms = 0;
+static uint32_t last_invite_ms = 0;
+static uint32_t pair_window_end_ms = 0;
+/* Written on the main task, read on the WiFi task. */
+static volatile bool net_active = false;
+static volatile int sync_status = NET_SYNC_OFF;
+static volatile uint32_t session_id = 0;
+
+static void on_data_recv(const esp_now_recv_info_t *info, const uint8_t *data, int len)
+{
+  knobby_net_packet_t pkt = {}; /* INVITE fills only the header */
+  knobby_net_rx_t rx;
+  if (!net_active || rx_queue == NULL) return;
+  if (len < (int)KNOBBY_NET_HDR_LEN || len > (int)sizeof(pkt)) return;
+  memcpy(&pkt, data, len);
+  if (pkt.magic != KNOBBY_NET_MAGIC || pkt.version != KNOBBY_NET_VERSION) return;
+
+  if (pkt.type == KNOBBY_PKT_STATE) {
+    /* Only state for the game we're in (a joiner has session 0, which
+       matches nothing: senders never broadcast a zero session). */
+    if (len != (int)KNOBBY_NET_STATE_LEN) return;
+    if (session_id == 0 || pkt.session != session_id) return;
+  } else if (pkt.type == KNOBBY_PKT_NAMES) {
+    if (len != (int)KNOBBY_NET_NAMES_LEN) return;
+    if (session_id == 0 || pkt.session != session_id) return;
+  } else if (pkt.type == KNOBBY_PKT_INVITE) {
+    if (len != (int)KNOBBY_NET_HDR_LEN) return;
+    if (sync_status != NET_SYNC_JOINING || pkt.session == 0) return;
+  } else {
+    return;
+  }
+
+  rx.type = pkt.type;
+  rx.session = pkt.session;
+  rx.body = pkt.body;
+  /* Both devices must pick the same winner on equal versions, so ties go
+     to the higher MAC — each side compares the same two addresses. */
+  rx.wins_ties = (memcmp(info->src_addr, my_mac, sizeof(my_mac)) > 0) ? 1 : 0;
+  /* Drop when full rather than block the WiFi task; snapshots are
+     self-healing, the next one carries everything. */
+  xQueueSend(rx_queue, &rx, 0);
+}
+
+static bool knobby_net_radio_up(void)
+{
+  if (net_active) return true;
+  if (rx_queue == NULL) {
+    rx_queue = xQueueCreate(8, sizeof(knobby_net_rx_t));
+    if (rx_queue == NULL) return false;
+  }
+  /* Stale packets from a previous enable must not apply now. */
+  xQueueReset(rx_queue);
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect();
+  /* ESP-NOW RX needs the receiver always listening; pin that intent even
+     if a future core changes the disconnected-STA power-save default. */
+  WiFi.setSleep(false);
+  WiFi.macAddress(my_mac);
+  if (esp_now_init() != ESP_OK) {
+    WiFi.mode(WIFI_OFF);
+    return false;
+  }
+  esp_now_peer_info_t peer = {};
+  memcpy(peer.peer_addr, broadcast_mac, sizeof(broadcast_mac));
+  peer.channel = 0; /* 0 = whatever channel the STA interface is on */
+  peer.encrypt = false;
+  if (esp_now_add_peer(&peer) != ESP_OK ||
+      esp_now_register_recv_cb(on_data_recv) != ESP_OK) {
+    esp_now_deinit();
+    WiFi.mode(WIFI_OFF);
+    return false;
+  }
+  net_active = true;
+  return true;
+}
+
+static void knobby_net_radio_down(void)
+{
+  if (!net_active) return;
+  net_active = false;
+  esp_now_unregister_recv_cb();
+  /* esp_wifi_stop() serializes with the WiFi task, so no receive
+     callback can be in flight when ESP-NOW is torn down below. */
+  esp_wifi_stop();
+  esp_now_deinit();
+  WiFi.mode(WIFI_OFF);
+}
+
+static void knobby_net_send(uint8_t type)
+{
+  knobby_net_packet_t pkt = {};
+  if (!net_active || session_id == 0) return;
+  pkt.magic = KNOBBY_NET_MAGIC;
+  pkt.version = KNOBBY_NET_VERSION;
+  pkt.type = type;
+  pkt.session = session_id;
+  /* Stamp timestamps only on accepted sends: a driver-rejected packet
+     (e.g. ESP_ERR_ESPNOW_NO_MEM under bursts) must not silence the
+     beacon or the reply throttle for a snapshot that never aired. */
+  if (type == KNOBBY_PKT_STATE) {
+    net_sync_fill_state(&pkt.body.state);
+    if (esp_now_send(broadcast_mac, (const uint8_t *)&pkt,
+                     KNOBBY_NET_STATE_LEN) == ESP_OK) {
+      last_tx_ms = millis();
+    }
+  } else if (type == KNOBBY_PKT_NAMES) {
+    net_sync_fill_names(&pkt.body.names);
+    esp_now_send(broadcast_mac, (const uint8_t *)&pkt, KNOBBY_NET_NAMES_LEN);
+  } else {
+    if (esp_now_send(broadcast_mac, (const uint8_t *)&pkt,
+                     KNOBBY_NET_HDR_LEN) == ESP_OK) {
+      last_invite_ms = millis();
+    }
+  }
+}
+
+bool knobby_net_active(void)
+{
+  return net_active;
+}
+
+void knobby_net_process(void)
+{
+  knobby_net_rx_t rx;
+  uint32_t now;
+
+  if (!net_active || rx_queue == NULL) return;
+
+  while (xQueueReceive(rx_queue, &rx, 0) == pdTRUE) {
+    /* Re-validate against the CURRENT session — Start/Join may have
+       changed it after this packet passed the callback's filter. */
+    if (rx.type == KNOBBY_PKT_STATE) {
+      if (rx.session == session_id && session_id != 0) {
+        net_sync_apply_state(&rx.body.state, rx.wins_ties);
+      }
+    } else if (rx.type == KNOBBY_PKT_NAMES) {
+      if (rx.session == session_id && session_id != 0) {
+        net_sync_apply_names(&rx.body.names, rx.wins_ties);
+      }
+    } else if (rx.type == KNOBBY_PKT_INVITE &&
+               sync_status == NET_SYNC_JOINING) {
+      /* Adopt the table NOW, not at Join-press: wiping here means
+         nothing armed during the join window (a reset, a rename, a
+         game-mode Apply) can outrank the live game — and a join that
+         times out has wiped nothing from the local game. */
+      net_sync_reset_versions();
+      session_id = rx.session;
+      sync_status = NET_SYNC_IN_GAME;
+    }
+  }
+
+  now = millis();
+  if (sync_status == NET_SYNC_HOSTING) {
+    if ((int32_t)(now - pair_window_end_ms) >= 0) {
+      sync_status = NET_SYNC_IN_GAME;
+      /* One last roster push for anyone who joined late in the window. */
+      knobby_net_send(KNOBBY_PKT_NAMES);
+    } else if (now - last_invite_ms >= KNOBBY_NET_INVITE_PERIOD_MS) {
+      knobby_net_send(KNOBBY_PKT_INVITE);
+      /* Names travel with invites instead of riding the steady-state
+         beacon. A joiner always misses the companion of the invite it
+         adopts (its session is set a beat later), so delivery is the
+         NEXT 1s tick, the window-close push, or the anti-entropy
+         reply to its first stale packet. */
+      knobby_net_send(KNOBBY_PKT_NAMES);
+    }
+  } else if (sync_status == NET_SYNC_JOINING) {
+    if ((int32_t)(now - pair_window_end_ms) >= 0) {
+      net_sync_leave_game(); /* nothing found: back to off */
+      return;
+    }
+  }
+  if (session_id != 0 && now - last_tx_ms >= KNOBBY_NET_BEACON_MS) {
+    knobby_net_send(KNOBBY_PKT_STATE);
+  }
+}
+
+extern "C" void net_sync_send_state(void)
+{
+  knobby_net_send(KNOBBY_PKT_STATE);
+}
+
+extern "C" void net_sync_send_names(void)
+{
+  knobby_net_send(KNOBBY_PKT_NAMES);
+}
+
+extern "C" void net_sync_send_reply(void)
+{
+  /* Two devices can each judge the other stale (mutual-stale is
+     reachable at exactly 0x8000 of version divergence), so replies
+     are rate-limited; short of that pathological edge, the 5s beacon
+     repairs everything. */
+  if (millis() - last_tx_ms < 250) return;
+  knobby_net_send(KNOBBY_PKT_STATE);
+  /* The reply doubles as roster delivery: a joiner that lost the
+     invite-window names packet beacons a stale epoch within 5s, and
+     names are otherwise never repaired. */
+  knobby_net_send(KNOBBY_PKT_NAMES);
+}
+
+extern "C" int net_sync_start_game(void)
+{
+  uint32_t id;
+  if (!knobby_net_radio_up()) return 0;
+  if (session_id != 0) {
+    /* Already in a game: re-open the invite window for the SAME
+       session so late joiners and rebooted devices can (re)join —
+       re-keying here would silently orphan every existing peer. */
+    sync_status = NET_SYNC_HOSTING;
+    pair_window_end_ms = millis() + KNOBBY_NET_PAIR_WINDOW_MS;
+    knobby_net_send(KNOBBY_PKT_INVITE);
+    return 1;
+  }
+  do { id = esp_random(); } while (id == 0);
+  xQueueReset(rx_queue); /* radio may already be up (e.g. was JOINING) */
+  net_sync_begin_game();
+  session_id = id;
+  sync_status = NET_SYNC_HOSTING;
+  pair_window_end_ms = millis() + KNOBBY_NET_PAIR_WINDOW_MS;
+  knobby_net_send(KNOBBY_PKT_INVITE);
+  knobby_net_send(KNOBBY_PKT_STATE);
+  knobby_net_send(KNOBBY_PKT_NAMES);
+  return 1;
+}
+
+extern "C" int net_sync_join_game(void)
+{
+  if (!knobby_net_radio_up()) return 0;
+  session_id = 0; /* joining implies leaving the previous game */
+  xQueueReset(rx_queue);
+  /* Versions/bookkeeping are wiped at invite ADOPTION, not here — see
+     knobby_net_process. */
+  sync_status = NET_SYNC_JOINING;
+  pair_window_end_ms = millis() + KNOBBY_NET_PAIR_WINDOW_MS;
+  return 1;
+}
+
+extern "C" void net_sync_leave_game(void)
+{
+  knobby_net_radio_down();
+  session_id = 0;
+  sync_status = NET_SYNC_OFF;
+}
+
+extern "C" int net_sync_status(void)
+{
+  return sync_status;
+}
+
+extern "C" int net_sync_code(void)
+{
+  uint32_t id = session_id;
+  return (id != 0) ? (int)(id % 10000u) : -1;
+}

--- a/knobby/knobby_net.h
+++ b/knobby/knobby_net.h
@@ -1,0 +1,9 @@
+#ifndef _KNOBBY_NET_H
+#define _KNOBBY_NET_H
+
+/* Firmware-only radio side of Table Sync (see src/net_sync.h). */
+
+void knobby_net_process(void);
+bool knobby_net_active(void);
+
+#endif

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -303,20 +303,6 @@ lv_color_t get_effective_player_color(int player_i, int color_i, int vibrancy)
     return get_player_color_vib(color_i, vibrancy);
 }
 
-int get_main_player_index(void)
-{
-    int num = nvs_get_num_players();
-    int i;
-
-    for (i = 0; i < num; i++) {
-        if (strcmp(player_names[i], "m") == 0) {
-            return i;
-        }
-    }
-
-    return -1;
-}
-
 int get_cmd_target_player_index(int row)
 {
     int skip_player;
@@ -329,11 +315,11 @@ int get_cmd_target_player_index(int row)
     if (cmd_damage_target >= 0) {
         skip_player = cmd_damage_target;
     } else {
-        skip_player = get_main_player_index();
-    }
-
-    if (skip_player < 0) {
-        return row;
+        /* No explicit target — only hidden-screen repaints and the
+           sim's direct navigation reach this (every live flow sets
+           cmd_damage_target first): map as if the owner, player 0,
+           were the target, so the enemy rows show players 1..n-1. */
+        skip_player = 0;
     }
 
     for (i = 0; i < num; i++) {

--- a/knobby/src/game.c
+++ b/knobby/src/game.c
@@ -2,11 +2,13 @@
 #include "storage.h"
 #include "damage_log.h"
 #include "esp_random.h"
+#include "net_sync.h"
 // Forward declarations for UI refresh (defined in screen modules)
 extern void refresh_player_ui(void);
 extern void refresh_select_ui(void);
 extern void refresh_damage_ui(void);
 extern void refresh_all_damage_ui(void);
+extern void refresh_rename_ui(void);
 extern void select_kick_timer(void);
 
 // ---------- state ----------
@@ -53,6 +55,57 @@ static elimination_action_t elimination_action[MAX_DISPLAY_PLAYERS] = {{0}};
 
 
 static lv_timer_t *life_preview_timer = NULL;
+
+/* Per-player Lamport versions for Table Sync, scoped by a game epoch.
+   Every local commit bumps the touched player's version and broadcasts
+   a full state snapshot; adopting a remote block adopts its version.
+   The epoch dominates the comparison (see net_sync_apply_state), so
+   versions from different games are never compared against each other.
+   uint16 wrap is handled with serial arithmetic. */
+static uint16_t game_epoch = 0;
+static uint16_t player_version[MAX_DISPLAY_PLAYERS] = {0};
+static uint16_t names_version = 0;
+
+static void clear_player_elimination_action(int player);
+
+static void net_sync_commit_player(int player)
+{
+    player_version[player]++;
+    net_sync_send_state();
+}
+
+void net_sync_commit_names(void)
+{
+    names_version++;
+    net_sync_send_names();
+}
+
+void net_sync_begin_game(void)
+{
+    int i;
+    game_epoch++;
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) player_version[i] = 1;
+    /* Names outlive game resets, so a mid-session reset leaves the
+       roster version alone. A fresh host must still seed it above a
+       joiner's zero, or the joiner's leftover roster could win the
+       first tie. */
+    if (names_version == 0) names_version = 1;
+}
+
+void net_sync_reset_versions(void)
+{
+    int i;
+    game_epoch = 0;
+    memset(player_version, 0, sizeof(player_version));
+    names_version = 0;
+    /* Joining a table: elimination-undo bookkeeping and the event log
+       refer to a game this device is leaving behind; replaying either
+       against adopted state would corrupt life and mirror the
+       corruption table-wide. */
+    for (i = 0; i < MAX_DISPLAY_PLAYERS; i++)
+        clear_player_elimination_action(i);
+    damage_log_reset();
+}
 
 #define MANA_ICON_COMMANDER "\xEE\xA7\x86"
 #define MANA_ICON_PARTY     "\xEE\xA6\x87"
@@ -167,16 +220,36 @@ void manual_eliminate_player(int player)
         player_selected[player] = false;
         select_kick_timer();
     }
+    net_sync_commit_player(player);
     refresh_player_ui();
 }
 
 void manual_uneliminate_player(int player)
 {
+    int i;
     if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return;
     if (!player_eliminated[player]) return;
     player_eliminated[player] = false;
     player_manually_eliminated[player] = false;
     clear_player_elimination_action(player);
+    /* A remotely-caused elimination arrives with no local
+       elimination_action to undo, so revival must also clear whatever
+       condition would instantly re-kill the player — otherwise they
+       come back at e.g. -2 life and re-die on the next touch. Pull
+       each lethal condition just below its threshold, but only when
+       auto-elimination would actually re-fire (same gate as
+       check_player_elimination): with it off, life <= 0 or poison >=
+       10 are legitimate alive states that must not be rewritten. */
+    if (nvs_get_auto_eliminate() && nvs_get_players_to_track() > 1) {
+        if (player_life[player] < 1) player_life[player] = 1;
+        if (player_counters[player][COUNTER_TYPE_POISON] > 9)
+            player_counters[player][COUNTER_TYPE_POISON] = 9;
+        for (i = 0; i < MAX_GAME_PLAYERS; i++) {
+            if (cmd_damage_totals[i][player] > 20)
+                cmd_damage_totals[i][player] = 20;
+        }
+    }
+    net_sync_commit_player(player);
     refresh_player_ui();
 }
 
@@ -375,6 +448,8 @@ int apply_counter_edit(void)
 
     if (player < 0 || player >= MAX_DISPLAY_PLAYERS) return 0;
     if (counter_edit_type < 0 || counter_edit_type >= COUNTER_TYPE_COUNT) return 0;
+    /* Same remote-elimination race guard as damage_apply. */
+    if (player_eliminated[player]) return 0;
 
     old_value = player_counters[player][counter_edit_type];
     counter_edit_value = clamp_counter(counter_edit_value);
@@ -390,6 +465,7 @@ int apply_counter_edit(void)
         if (counter_edit_type == COUNTER_TYPE_POISON) {
             check_player_elimination(player);
         }
+        net_sync_commit_player(player);
     }
 
     return change_delta;
@@ -446,6 +522,7 @@ void apply_life_delta(int player, int delta)
         set_player_elimination_action(player, LOG_EVT_LIFE, -1, delta);
     }
     check_player_elimination(player);
+    net_sync_commit_player(player);
 }
 
 // ---------- life preview ----------
@@ -511,6 +588,11 @@ void damage_apply(void)
 
     if (selected_enemy < 0 || selected_enemy >= active_enemy_count) return;
     if (cmd_damage_target < 0 || cmd_damage_target >= MAX_DISPLAY_PLAYERS) return;
+    /* Unreachable locally (the editor only opens for a live target),
+       but a remote elimination can race an open editor: eliminated
+       players accrue no more (same rule as apply_life_delta), and
+       committing here would overwrite their elimination-undo action. */
+    if (player_eliminated[cmd_damage_target]) return;
 
     delta = enemies[selected_enemy].damage - damage_start_value;
     if (delta == 0) return;
@@ -523,6 +605,7 @@ void damage_apply(void)
         set_player_elimination_action(cmd_damage_target, LOG_EVT_CMD_DAMAGE, source, -delta);
     }
     check_player_elimination(cmd_damage_target);
+    net_sync_commit_player(cmd_damage_target);
 
     refresh_select_ui();
 }
@@ -605,6 +688,7 @@ void undo_life_change(int player, int delta)
 
     player_life[player] = clamp_life(player_life[player] - delta);
     check_player_elimination(player);
+    net_sync_commit_player(player);
     refresh_player_ui();
     refresh_select_ui();
 }
@@ -617,6 +701,7 @@ void undo_cmd_damage(int source, int target, int delta)
     if (cmd_damage_totals[source][target] < 0)
         cmd_damage_totals[source][target] = 0;
     check_player_elimination(target);
+    net_sync_commit_player(target);
 }
 
 void undo_counter_change(int player, int counter_type, int delta)
@@ -630,6 +715,7 @@ void undo_counter_change(int player, int counter_type, int delta)
     if (counter_type == COUNTER_TYPE_POISON) {
         check_player_elimination(player);
     }
+    net_sync_commit_player(player);
     refresh_player_ui();
 }
 
@@ -669,6 +755,11 @@ void knob_life_reset(void)
     all_damage_value = 0;
     counter_edit_type = COUNTER_TYPE_COMMANDER_TAX;
     counter_edit_value = 0;
+
+    /* A reset starts a new game: bump the epoch (which outranks any
+       version drift a strayed device accumulated) and broadcast once. */
+    net_sync_begin_game();
+    net_sync_send_state();
 
     if (life_preview_timer != NULL) {
         lv_timer_pause(life_preview_timer);
@@ -775,4 +866,198 @@ void stop_player_selection_animation(void)
 bool player_selection_animation_active(void)
 {
     return player_select_anim_timer != NULL && player_select_anim_steps > 0;
+}
+
+// ---------- table sync (ESP-NOW) ----------
+_Static_assert(NET_SYNC_MAX_PLAYERS == MAX_DISPLAY_PLAYERS, "packet layout");
+_Static_assert(NET_SYNC_MAX_SOURCES == MAX_GAME_PLAYERS, "packet layout");
+_Static_assert(sizeof(((net_sync_player_t *)0)->counters) / sizeof(int16_t)
+               == COUNTER_TYPE_COUNT, "packet layout");
+_Static_assert(sizeof(((net_sync_names_t *)0)->names) == sizeof(player_names),
+               "packet layout");
+
+void net_sync_fill_names(net_sync_names_t *out)
+{
+    int i;
+    /* Copy per-row through snprintf, not one memcpy: bytes past each
+       name's NUL are residue from earlier longer names and must not
+       go out on the air (also keeps roster comparison canonical). */
+    memset(out, 0, sizeof(*out));
+    out->version = names_version;
+    for (i = 0; i < MAX_GAME_PLAYERS; i++)
+        snprintf(out->names[i], NET_SYNC_NAME_LEN, "%s", player_names[i]);
+}
+
+/* Adopt a remote roster. Whole-set LWW on the roster version (serial
+   arithmetic, MAC tiebreak), like a single state block. Runs on the
+   main task, same as net_sync_apply_state. */
+void net_sync_apply_names(const net_sync_names_t *in, int wins_ties)
+{
+    int16_t newer = (int16_t)(in->version - names_version);
+    int i;
+
+    if (newer < 0) {
+        /* Same self-healing as state: answer a stale roster so the
+           sender converges without waiting for a rename or invite. */
+        net_sync_send_reply();
+        return;
+    }
+    if (newer == 0 && !wins_ties) return;
+    names_version = in->version;
+    if (memcmp(player_names, in->names, sizeof(player_names)) == 0) return;
+    memcpy(player_names, in->names, sizeof(player_names));
+    /* Wire bytes are untrusted: every name must terminate. */
+    for (i = 0; i < MAX_GAME_PLAYERS; i++)
+        player_names[i][sizeof(player_names[i]) - 1] = '\0';
+    /* Same refresh set as a local rename (rename.c). */
+    refresh_player_ui();
+    refresh_select_ui();
+    refresh_damage_ui();
+    refresh_rename_ui();
+}
+
+void net_sync_fill_state(net_sync_state_t *out)
+{
+    int p, s, c;
+
+    memset(out, 0, sizeof(*out));
+    out->epoch = game_epoch;
+    for (p = 0; p < MAX_DISPLAY_PLAYERS; p++) {
+        net_sync_player_t *rp = &out->players[p];
+        rp->version = player_version[p];
+        rp->life = (int16_t)player_life[p];
+        for (c = 0; c < COUNTER_TYPE_COUNT; c++)
+            rp->counters[c] = (int16_t)player_counters[p][c];
+        for (s = 0; s < MAX_GAME_PLAYERS; s++) {
+            int v = cmd_damage_totals[s][p];
+            rp->cmd_damage[s] = (uint8_t)((v < 0) ? 0 : (v > 255) ? 255 : v);
+        }
+        if (player_eliminated[p]) rp->eliminated |= NET_SYNC_ELIM;
+        if (player_manually_eliminated[p]) rp->eliminated |= NET_SYNC_ELIM_MANUAL;
+    }
+}
+
+/* Adopt a remote state snapshot. Runs on the main (LVGL) task — packets
+   are queued by the radio and drained from loop() — so UI refresh is
+   safe here. The game epoch dominates: a newer epoch (new game started
+   or reset elsewhere) is adopted wholesale, an older one is rejected
+   and answered with our own state (anti-entropy: the stale device
+   converges in one exchange instead of waiting out the beacon). Within
+   the same epoch, a player's block is adopted iff its version is newer
+   (serial arithmetic, so uint16 wrap is fine); equal versions defer to
+   the sender with the higher MAC so both devices pick the same winner.
+
+   State is adopted directly — never route remote state through the
+   apply/undo helpers: they bump versions and re-broadcast, and they'd
+   re-derive elimination that the sender already decided. The damage
+   log stays a per-device view of local actions. */
+void net_sync_apply_state(const net_sync_state_t *in, int wins_ties)
+{
+    bool changed = false;
+    bool remote_stale = false;
+    int16_t epoch_newer = (int16_t)(in->epoch - game_epoch);
+    int p, s, c;
+
+    if (epoch_newer < 0) {
+        net_sync_send_reply();
+        return;
+    }
+    if (epoch_newer > 0) {
+        game_epoch = in->epoch;
+        /* A new game from the table: local elimination-undo actions
+           and the event log refer to a game that no longer exists
+           (see net_sync_reset_versions). */
+        for (p = 0; p < MAX_DISPLAY_PLAYERS; p++)
+            clear_player_elimination_action(p);
+        damage_log_reset();
+    }
+
+    for (p = 0; p < MAX_DISPLAY_PLAYERS; p++) {
+        const net_sync_player_t *rp = &in->players[p];
+        int16_t newer = (int16_t)(rp->version - player_version[p]);
+        bool was_eliminated = player_eliminated[p];
+        bool now_eliminated = (rp->eliminated & NET_SYNC_ELIM) != 0;
+        bool p_changed = false;
+        int life = clamp_life(rp->life);
+
+        /* Same epoch: per-player Lamport rule. A newer epoch adopts
+           every block regardless of version drift. */
+        if (epoch_newer == 0 && (newer < 0 || (newer == 0 && !wins_ties))) {
+            if (newer < 0) remote_stale = true;
+            continue;
+        }
+
+        if (player_life[p] != life) {
+            player_life[p] = life;
+            /* A pending preview was dialed against a total that no
+               longer exists: if this player is in the current
+               selection, drop the whole group's proposal (it is one
+               shared delta) so a duplicate entry can't silently
+               double-apply — the user sees the total snap and can
+               re-dial. Changes to unselected players compose as
+               usual. The selection itself stays: the grouping is
+               still valid intent, only the number was invalidated. */
+            if (life_preview_active && player_selected[p]) {
+                pending_life_delta = 0;
+                life_preview_active = false;
+                if (life_preview_timer != NULL) {
+                    lv_timer_pause(life_preview_timer);
+                }
+                select_kick_timer();
+            }
+            p_changed = true;
+        }
+        for (c = 0; c < COUNTER_TYPE_COUNT; c++) {
+            int v = clamp_counter(rp->counters[c]);
+            if (player_counters[p][c] != v) {
+                player_counters[p][c] = v;
+                p_changed = true;
+            }
+        }
+        for (s = 0; s < MAX_GAME_PLAYERS; s++) {
+            if (cmd_damage_totals[s][p] != rp->cmd_damage[s]) {
+                cmd_damage_totals[s][p] = rp->cmd_damage[s];
+                p_changed = true;
+            }
+        }
+        if (was_eliminated != now_eliminated) {
+            player_eliminated[p] = now_eliminated;
+            if (!now_eliminated) {
+                clear_player_elimination_action(p);
+            } else if (player_selected[p]) {
+                /* Same rule as check_player_elimination: an eliminated
+                   player leaves the selection set. */
+                player_selected[p] = false;
+                select_kick_timer();
+            }
+            p_changed = true;
+        } else if (was_eliminated && p_changed) {
+            /* Still eliminated but the block changed underneath (a
+               missed revive+re-kill): the stored undo action belongs
+               to the old elimination and would restore the wrong
+               amount. Undo then falls back to the revive clamps. */
+            clear_player_elimination_action(p);
+        }
+        player_manually_eliminated[p] =
+            now_eliminated && (rp->eliminated & NET_SYNC_ELIM_MANUAL) != 0;
+        player_version[p] = rp->version;
+        changed = changed || p_changed;
+    }
+
+    if (changed) {
+        refresh_player_ui();
+        refresh_select_ui();
+    }
+    /* The sender is behind and we adopted nothing: answer immediately
+       so its lost-update window is one exchange, not a 5s beacon. */
+    if (remote_stale && !changed) {
+        net_sync_send_reply();
+    }
+    /* A fresh joiner can adopt the table's epoch while still awaiting
+       the roster (every invite-window names packet lost): announcing
+       its version-0 roster makes any peer see it as stale and reply
+       with the real one (see net_sync_apply_names). */
+    if (epoch_newer > 0 && names_version == 0) {
+        net_sync_send_names();
+    }
 }

--- a/knobby/src/game.h
+++ b/knobby/src/game.h
@@ -91,7 +91,6 @@ lv_color_t get_player_preview_color(int index, int delta);
 lv_color_t get_custom_color_vib(int index, int vibrancy);
 const char *get_custom_color_name(int index);
 lv_color_t get_effective_player_color(int player_i, int color_i, int vibrancy);
-int get_main_player_index(void);
 int get_cmd_target_player_index(int row);
 
 #endif // _GAME_H

--- a/knobby/src/game_mode.c
+++ b/knobby/src/game_mode.c
@@ -2,6 +2,7 @@
 #include "storage.h"
 #include "settings.h"
 #include "ui_mp.h"
+#include "net_sync.h"
 
 // Forward declarations
 extern void reset_all_values(void);
@@ -118,6 +119,13 @@ static void event_gm_life_custom(lv_event_t *e)
 static void event_gm_apply(lv_event_t *e)
 {
     (void)e;
+    /* Applying game mode redefines the game (players, view, starting
+       life), and settings don't sync — so rather than broadcasting a
+       reset at THIS device's config over the whole table, leave the
+       session before the reset below can reach it. Same-config new
+       games use the shared reset; config changes re-pair. (No-op when
+       not synced.) */
+    net_sync_leave_game();
     nvs_set_num_players(temp_num_players);
     nvs_set_players_to_track(temp_players_to_track);
     nvs_set_life_total(temp_life_total);

--- a/knobby/src/hw.c
+++ b/knobby/src/hw.c
@@ -1,5 +1,6 @@
 #include "hw.h"
 #include "storage.h"
+#include "net_sync.h"
 #include "driver/ledc.h"
 #include "esp_sleep.h"
 
@@ -100,6 +101,12 @@ static void check_low_battery_cutoff(void)
 
 void knob_enter_deep_sleep(void)
 {
+    /* Deep sleep with the WiFi driver live violates the IDF sleep
+       contract (and this path is reachable while Table Sync is on).
+       The wake is a full reboot, so the game is left for good — a
+       recharged device rejoins via the in-game Invite. */
+    net_sync_leave_game();
+
     // Turn off backlight
     ledc_set_duty(BACKLIGHT_LEDC_MODE, BACKLIGHT_LEDC_CHANNEL, 0);
     ledc_update_duty(BACKLIGHT_LEDC_MODE, BACKLIGHT_LEDC_CHANNEL);

--- a/knobby/src/net_sync.h
+++ b/knobby/src/net_sync.h
@@ -1,0 +1,88 @@
+#ifndef _NET_SYNC_H
+#define _NET_SYNC_H
+
+#include <stdint.h>
+
+/* Table Sync: mirrors the whole game state between Knobby devices over
+   ESP-NOW. Every packet carries a full state snapshot with a per-player
+   Lamport version; receivers adopt a player's block iff its version is
+   newer (ties broken by sender MAC), so lost packets self-heal on the
+   next broadcast and devices converge instead of diverging.
+
+   The radio side lives in knobby/knobby_net.cpp (firmware only); the
+   simulator links the no-op bridges in sim/sim_stubs.c. The state
+   builders/appliers live in game.c and must only run on the main
+   (LVGL) task. */
+
+#define NET_SYNC_MAX_PLAYERS 4  /* == MAX_DISPLAY_PLAYERS */
+#define NET_SYNC_MAX_SOURCES 8  /* == MAX_GAME_PLAYERS    */
+
+#define NET_SYNC_ELIM      0x01 /* eliminated flag bits */
+#define NET_SYNC_ELIM_MANUAL 0x02
+
+typedef struct __attribute__((packed)) {
+    uint16_t version;    /* per-player Lamport version, wraps (serial arithmetic) */
+    int16_t  life;
+    int16_t  counters[4];                    /* == COUNTER_TYPE_COUNT */
+    uint8_t  cmd_damage[NET_SYNC_MAX_SOURCES]; /* column of cmd_damage_totals */
+    uint8_t  eliminated;                     /* NET_SYNC_ELIM* bits */
+    uint8_t  reserved;                       /* keeps u16 fields even-aligned */
+} net_sync_player_t;
+
+typedef struct __attribute__((packed)) {
+    /* Game epoch dominates the per-player version comparison: a newer
+       epoch is adopted wholesale, an older one is rejected outright.
+       Bumped by Start Game and by reset, zeroed on join — so versions
+       left over from an earlier game can never outrank the current one. */
+    uint16_t epoch;
+    uint16_t reserved;
+    net_sync_player_t players[NET_SYNC_MAX_PLAYERS];
+} net_sync_state_t;
+
+#define NET_SYNC_NAME_LEN 16 /* == sizeof(player_names[0]) */
+
+typedef struct __attribute__((packed)) {
+    /* One version for the whole roster (not per-name): renames are
+       rare, setup-time edits, so set-level LWW is enough. Deliberately
+       epoch-independent — names outlive game resets. */
+    uint16_t version;
+    char names[NET_SYNC_MAX_SOURCES][NET_SYNC_NAME_LEN];
+} net_sync_names_t;
+
+/* Implemented in game.c */
+void net_sync_fill_state(net_sync_state_t *out);
+void net_sync_apply_state(const net_sync_state_t *in, int wins_ties);
+void net_sync_fill_names(net_sync_names_t *out);
+void net_sync_apply_names(const net_sync_names_t *in, int wins_ties);
+void net_sync_commit_names(void);   /* rename hook: bump + broadcast */
+void net_sync_begin_game(void);     /* host: new epoch, fresh versions */
+void net_sync_reset_versions(void); /* joiner: forget all, adopt the table */
+
+/* Pairing: a game is identified by a random 32-bit session ID. "Start
+   Game" generates one and broadcasts invites for a short window; "Join
+   Game" listens for an invite and adopts its session. Only packets
+   carrying the matching session are accepted, so tables in radio range
+   don't merge. Sessions are RAM-only: a reboot always comes up with
+   the radio off, and a rebooted device rejoins via the in-game Invite
+   action (which re-opens the window for the same session). */
+typedef enum {
+    NET_SYNC_OFF = 0,
+    NET_SYNC_JOINING,  /* listening for an invite */
+    NET_SYNC_HOSTING,  /* in game, invite window still open */
+    NET_SYNC_IN_GAME,
+} net_sync_status_t;
+
+/* Radio bridges: knobby_net.cpp on firmware, sim_stubs.c in the sim.
+   start/join return nonzero if the radio came up. net_sync_send_reply
+   is the rate-limited variant for anti-entropy answers (a reply can
+   itself trigger a reply, so it must not be storm-capable). */
+void net_sync_send_state(void);
+void net_sync_send_names(void);
+void net_sync_send_reply(void);
+int net_sync_start_game(void);
+int net_sync_join_game(void);
+void net_sync_leave_game(void);
+int net_sync_status(void);     /* net_sync_status_t */
+int net_sync_code(void);       /* 4-digit game code, -1 when no session */
+
+#endif

--- a/knobby/src/rename.c
+++ b/knobby/src/rename.c
@@ -4,6 +4,7 @@
 #include "ui_1p.h"
 #include "game.h"
 #include "storage.h"
+#include "net_sync.h"
 #include <string.h>
 
 // ---------- screens ----------
@@ -99,8 +100,15 @@ static void rename_all_advance(void)
 // ---------- apply + return ----------
 static void apply_name_and_return(const char *name)
 {
-    snprintf(player_names[menu_player],
-             sizeof(player_names[menu_player]), "%s", name);
+    /* Unchanged name (e.g. the "keep current" row, where name aliases
+       the destination buffer): skip the write — snprintf with
+       overlapping src/dst is UB — and the broadcast, so a no-op
+       re-apply can't win a version tie against a real remote rename. */
+    if (strcmp(player_names[menu_player], name) != 0) {
+        snprintf(player_names[menu_player],
+                 sizeof(player_names[menu_player]), "%s", name);
+        net_sync_commit_names();
+    }
     if (!is_default_name(name))
         mru_use_name(name);
     refresh_multiplayer_ui();
@@ -129,6 +137,7 @@ static void event_name_save(lv_event_t *e)
         snprintf(player_names[menu_player],
                  sizeof(player_names[menu_player]),
                  "P%d", menu_player + 1);
+        net_sync_commit_names();
         refresh_multiplayer_ui();
         if (rename_all_active) {
             rename_all_advance();

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -9,6 +9,7 @@
 #include "rename.h"
 #include "game.h"
 #include "mana.h"
+#include "net_sync.h"
 
 // Forward declarations for cross-module calls
 extern void reset_all_values(void);
@@ -282,6 +283,123 @@ static void multi_select_set(int v)
     }
 }
 
+// ---------- table sync screen ----------
+lv_obj_t *screen_table_sync = NULL;
+static lv_obj_t *table_sync_action_lbl; /* Start <-> Invite quadrant */
+static lv_obj_t *table_sync_status_lbl; /* status tile */
+static lv_timer_t *table_sync_timer;
+static bool table_sync_radio_error;
+
+void refresh_table_sync_ui(void)
+{
+    static char status_buf[24];
+    int status = net_sync_status();
+    int code = net_sync_code();
+
+    switch (status) {
+        case NET_SYNC_JOINING:
+            snprintf(status_buf, sizeof(status_buf), "Joining...");
+            break;
+        case NET_SYNC_HOSTING:
+            snprintf(status_buf, sizeof(status_buf), "Inviting\n#%04d", code);
+            break;
+        case NET_SYNC_IN_GAME:
+            snprintf(status_buf, sizeof(status_buf), "In Game\n#%04d", code);
+            break;
+        default:
+            /* Sync is mirror-mode: a 1p view can't represent the shared
+               game, so pairing refuses below and the tile says why. */
+            if (nvs_get_players_to_track() <= 1)
+                snprintf(status_buf, sizeof(status_buf), "1P View:\nNo Sync");
+            else
+                snprintf(status_buf, sizeof(status_buf),
+                         table_sync_radio_error ? "Radio\nError" : "Sync Off");
+            break;
+    }
+    lv_label_set_text(table_sync_status_lbl, status_buf);
+    /* In a game the host action re-opens the invite window for the same
+       session (late joiners, rebooted devices) instead of re-keying. */
+    lv_label_set_text(table_sync_action_lbl,
+        (status == NET_SYNC_HOSTING || status == NET_SYNC_IN_GAME)
+            ? "Hold to\nInvite" : "Hold to\nStart");
+}
+
+static void event_table_sync_start(lv_event_t *e)
+{
+    (void)e;
+    if (nvs_get_players_to_track() <= 1) return;
+    table_sync_radio_error = !net_sync_start_game();
+    refresh_table_sync_ui();
+}
+
+static void event_table_sync_join(lv_event_t *e)
+{
+    (void)e;
+    if (nvs_get_players_to_track() <= 1) return;
+    table_sync_radio_error = !net_sync_join_game();
+    refresh_table_sync_ui();
+}
+
+static void event_table_sync_leave(lv_event_t *e)
+{
+    (void)e;
+    net_sync_leave_game();
+    table_sync_radio_error = false;
+    refresh_table_sync_ui();
+}
+
+/* Pairing runs in the background (invite window, join listening), so the
+   status tile has to track it while the screen is up. The timer pauses
+   itself when the user navigates away and is resumed on open. */
+static void table_sync_timer_cb(lv_timer_t *timer)
+{
+    if (lv_scr_act() != screen_table_sync) {
+        lv_timer_pause(timer);
+        return;
+    }
+    refresh_table_sync_ui();
+}
+
+void open_table_sync_screen(void)
+{
+    refresh_table_sync_ui();
+    lv_timer_resume(table_sync_timer);
+    lv_scr_load(screen_table_sync);
+}
+
+void build_table_sync_screen(void)
+{
+    quad_item_t items[4];
+
+    /* All three actions are destructive to a live game (Start opens or
+       re-invites, Join drops the current session, Leave exits), so they
+       require a long press. */
+    memset(items, 0, sizeof(items));
+    items[0].label = "Hold to\nStart";
+    items[0].cb = event_table_sync_start;
+    items[0].enabled = true;
+    items[0].event = LV_EVENT_LONG_PRESSED;
+    items[1].label = "Hold to\nJoin";
+    items[1].cb = event_table_sync_join;
+    items[1].enabled = true;
+    items[1].event = LV_EVENT_LONG_PRESSED;
+    items[2].label = "Hold to\nLeave";
+    items[2].cb = event_table_sync_leave;
+    items[2].enabled = true;
+    items[2].event = LV_EVENT_LONG_PRESSED;
+    items[3].label = "Sync Off"; /* status tile, refreshed live */
+    items[3].enabled = false;
+    items[3].event = LV_EVENT_CLICKED;
+
+    build_quad_screen(&screen_table_sync, items);
+    table_sync_action_lbl =
+        lv_obj_get_child(lv_obj_get_child(screen_table_sync, 0), 0);
+    table_sync_status_lbl =
+        lv_obj_get_child(lv_obj_get_child(screen_table_sync, 3), 0);
+    table_sync_timer = lv_timer_create(table_sync_timer_cb, 500, NULL);
+    lv_timer_pause(table_sync_timer);
+}
+
 static const setting_item_t settings_items[] = {
     { .id = "brightness",     .fixed_label = "Brightness", .navigate = open_settings_screen, .nav_screen = &screen_settings },
     { .id = "autodim",        .label = autodim_label,          .color = autodim_color,     .get = autodim_get,              .set = autodim_set,              .count = AUTO_DIM_COUNT },
@@ -292,6 +410,7 @@ static const setting_item_t settings_items[] = {
     { .id = "auto-eliminate", .label = auto_eliminate_label,   .color = toggle_color,      .get = nvs_get_auto_eliminate,   .set = nvs_set_auto_eliminate,   .count = 2 },
     { .id = "random-first",   .label = random_first_label,     .color = toggle_color,      .get = nvs_get_random_first,     .set = nvs_set_random_first,     .count = 2 },
     { .id = "multi-select",   .label = multi_select_label,     .color = toggle_color,      .get = nvs_get_multi_select,     .set = multi_select_set,         .count = 2 },
+    { .id = "table-sync",     .fixed_label = "Table Sync\n(Experimental)", .navigate = open_table_sync_screen, .nav_screen = &screen_table_sync },
 };
 #define SETTINGS_ITEM_COUNT ((int)(sizeof(settings_items) / sizeof(settings_items[0])))
 #define MAX_SETTINGS_PAGES  ((SETTINGS_ITEM_COUNT + 2) / 3)

--- a/knobby/src/settings.h
+++ b/knobby/src/settings.h
@@ -8,6 +8,7 @@ extern lv_obj_t *screen_quad_menu;
 extern lv_obj_t *screen_tools_menu;
 extern lv_obj_t *screen_settings;
 extern lv_obj_t *screen_battery;
+extern lv_obj_t *screen_table_sync;
 
 // ---------- declarative settings ----------
 /* One table in settings.c defines every user setting; pages and
@@ -34,10 +35,12 @@ void build_quad_screen(lv_obj_t **screen, quad_item_t items[4]);
 void build_quad_menus(void);
 void build_settings_screen(void);
 void build_battery_screen(void);
+void build_table_sync_screen(void);
 
 void refresh_settings_ui(void);
 void refresh_settings_pages_ui(void);
 void refresh_battery_ui(void);
+void refresh_table_sync_ui(void);
 
 bool settings_handle_back(lv_obj_t *screen);
 int settings_item_page(const char *id);
@@ -45,5 +48,6 @@ int settings_item_page(const char *id);
 void open_quad_menu(void);
 void open_settings_screen(void);
 void open_battery_screen(void);
+void open_table_sync_screen(void);
 
 #endif // _SETTINGS_H

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -274,6 +274,10 @@ for ms in 0 1; do
     shot "setting_multiselect_${ms_name[$ms]}.png" --screen setting:multi-select --multi-select "$ms"
 done
 
+shot "setting_tablesync_off.png"    --screen table-sync --track 4
+shot "setting_tablesync_ingame.png" --screen table-sync --track 4 --table-sync 1 --table-session 14242
+shot "setting_tablesync_1p.png"     --screen table-sync
+
 # All settings pages in their default state (count derived from the sim)
 NPAGES=$($SIM --print-settings-pages)
 for p in $(seq 1 "$NPAGES"); do

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -117,6 +117,7 @@ static void nav_tools(void)      { lv_scr_load(screen_tools_menu); }
 static void nav_settings_menu(void) { lv_scr_load(settings_pages[0]); }
 static void nav_brightness(void) { open_settings_screen(); }
 static void nav_battery(void)    { open_battery_screen(); }
+static void nav_table_sync(void) { open_table_sync_screen(); }
 static void nav_dice(void)       { open_dice_screen(); }
 static void nav_damage_log(void) { open_damage_log_screen(); }
 static void nav_game_mode(void)  { open_game_mode_menu(); }
@@ -160,6 +161,7 @@ static const screen_entry_t all_screens[] = {
     {"settings-menu", nav_settings_menu},
     {"brightness",    nav_brightness},
     {"battery",       nav_battery},
+    {"table-sync",    nav_table_sync},
     {"dice",          nav_dice},
     {"damage-log",    nav_damage_log},
     {"game-mode",     nav_game_mode},
@@ -235,6 +237,8 @@ static void print_usage(void)
            "  --auto-eliminate <n>   0=OFF, 1=ON (default: 1)\n"
            "  --random-first <n>     0=OFF, 1=ON random first-player pick on reset (default: 1)\n"
            "  --multi-select <n>     0=OFF, 1=ON (default: 0)\n"
+           "  --table-sync <n>       0=OFF, 1=ON ESP-NOW table sync (default: 0)\n"
+           "  --table-session <n>    Table sync game session ID, 0=none (default: 0)\n"
            "\nSpecial state:\n"
            "  --dice <n>             Set dice roll result (1-20)\n"
            "  --counter-type <n>     Counter type for counter-edit: 0=cmd tax, 1=partner tax,\n"
@@ -388,6 +392,10 @@ int main(int argc, char *argv[])
             selected_players_set = 1;
         } else if (strcmp(argv[i], "--multi-select") == 0 && i + 1 < argc) {
             sim_nvs_preset_i8("multi_sel", (int8_t)atoi(argv[++i]));
+        } else if (strcmp(argv[i], "--table-sync") == 0 && i + 1 < argc) {
+            sim_nvs_preset_i8("net_sync", (int8_t)atoi(argv[++i]));
+        } else if (strcmp(argv[i], "--table-session") == 0 && i + 1 < argc) {
+            sim_nvs_preset_u32("net_sessn", (uint32_t)strtoul(argv[++i], NULL, 10));
         } else if (strcmp(argv[i], "--preview-delta") == 0 && i + 1 < argc) {
             preview_delta = atoi(argv[++i]);
             preview_delta_set = 1;

--- a/sim/sim_stubs.c
+++ b/sim/sim_stubs.c
@@ -87,6 +87,12 @@ void sim_nvs_preset_i16(const char *key, int16_t value)
     if (e) { e->int_value = value; e->has_int = 1; }
 }
 
+void sim_nvs_preset_u32(const char *key, uint32_t value)
+{
+    nvs_entry_t *e = nvs_find_or_create(key);
+    if (e) { e->int_value = value; e->has_int = 1; }
+}
+
 /* NVS API stubs */
 
 esp_err_t nvs_flash_init(void) { return ESP_OK; }
@@ -211,6 +217,57 @@ void scr_display_on(void) { /* no-op in simulator */ }
 /* ---- Random ---- */
 
 uint32_t esp_random(void) { return (uint32_t)rand(); }
+
+/* ---- Table Sync ---- */
+
+/* Radio bridges implemented by knobby/knobby_net.cpp on firmware; the
+   simulator has no radio. Firmware sessions are RAM-only, so the fake
+   session lives in the sim's NVS store purely as a screenshot fixture:
+   --table-sync / --table-session preset it, and Start/Join/Leave behave
+   sensibly in the interactive sim (Join succeeds immediately — there is
+   no table to join). */
+#include "net_sync.h"
+
+static int64_t sim_nvs_value(const char *key)
+{
+    nvs_entry_t *e = nvs_find(key);
+    return (e && e->has_int) ? e->int_value : 0;
+}
+
+void net_sync_send_state(void) {}
+void net_sync_send_names(void) {}
+void net_sync_send_reply(void) {}
+
+int net_sync_start_game(void)
+{
+    sim_nvs_preset_i8("net_sync", 1);
+    sim_nvs_preset_u32("net_sessn", (esp_random() % 9999u) + 1u);
+    return 1;
+}
+
+int net_sync_join_game(void)
+{
+    return net_sync_start_game();
+}
+
+void net_sync_leave_game(void)
+{
+    sim_nvs_preset_i8("net_sync", 0);
+    sim_nvs_preset_u32("net_sessn", 0);
+}
+
+int net_sync_status(void)
+{
+    if (sim_nvs_value("net_sync") && sim_nvs_value("net_sessn") != 0)
+        return NET_SYNC_IN_GAME;
+    return NET_SYNC_OFF;
+}
+
+int net_sync_code(void)
+{
+    uint32_t id = (uint32_t)sim_nvs_value("net_sessn");
+    return (id != 0) ? (int)(id % 10000u) : -1;
+}
 
 /* ---- Shared test fixtures ---- */
 

--- a/sim/sim_stubs.h
+++ b/sim/sim_stubs.h
@@ -14,6 +14,7 @@ void sim_populate_random_log(void);
  * This lets CLI flags control settings that knob_nvs.c reads at init. */
 void sim_nvs_preset_i8(const char *key, int8_t value);
 void sim_nvs_preset_i16(const char *key, int16_t value);
+void sim_nvs_preset_u32(const char *key, uint32_t value);
 
 /* Controllable battery voltage for screenshots */
 extern float sim_battery_voltage;


### PR DESCRIPTION
# Table Sync (Experimental): ESP-NOW game-state mirroring between devices

A first concrete implementation of part of #11. Multiple Knobby devices at the same table can now pair into a shared game and mirror the full game state — life, all four counters, the commander damage matrix, eliminations, and player names. Any change committed on one device shows up on all of them within a beacon interval, resets and eliminations included, with no phone, app, or WiFi network involved.

## How it works

**Pairing UX.** Settings gains a `Table Sync (Experimental)` entry that opens a quad screen with **Hold to Start**, **Hold to Join**, **Hold to Leave**, and a live status tile (all three actions are long-press, since each is destructive to a live game). Start generates a random session and broadcasts invites for 30 s, showing a 4-digit game code on the tile; other devices Hold-to-Join and adopt the first invite heard, then show the same code so players can confirm they're on the same table. Once in a game, the same action becomes **Hold to Invite** — it re-opens the invite window for the *existing* session, so late joiners and rebooted devices can hop back in without re-keying everyone.

**Protocol.** Every commit broadcasts a full state snapshot over ESP-NOW broadcast (no pairing at the radio level; packets are filtered by a random 32-bit session ID, surfaced to users as the 4-digit code). Player names travel as a separate whole-roster packet with its own version, sent on rename and with invites. Adoption is decided by a game epoch (bumped on start/reset, dominates everything) plus per-player Lamport versions with a sender-MAC tiebreak, so devices converge instead of diverging and a reset or new game always outranks version drift. A 5 s repair beacon re-broadcasts state so lost packets self-heal without an ack layer, and a device that hears a stale sender answers immediately (rate-limited) with current state and names. Sessions are RAM-only: every boot comes up radio-off.

## What's in each commit

(The 16MB partition table this depends on landed separately as #114; this branch is rebased on top of it.)

- `93c3534` — Fix the 1p enemy mapping to treat player 0 as the device owner, replacing an undocumented magic-name (`m`) convention that nothing in the UI ever set. Independently cherry-pickable; worth taking even if the sync feature needs more bake time.
- `0fd15f5` — The Table Sync feature itself: transport + pairing state machine (`knobby/knobby_net.cpp`), wire format and convergence contract (`knobby/src/net_sync.h`), state fill/apply on the main task (`knobby/src/game.c`), and the pairing screen (`knobby/src/settings.c`). The simulator links no-op bridges so all shared code still builds headless.

## Design decisions worth reviewer attention

- **State snapshots, not event replication.** Broadcasting deltas ("player 2 −3") corrupts everyone when a packet is lost or crosses another; snapshots make every packet self-contained, so the beacon doubles as repair and rejoining is free. The cost is last-writer-wins on truly concurrent edits to the *same* player (see limitations).
- **Mirror mode only; 1p views refuse sync.** All devices must track the same players in the same slots. A 1p view can't represent the shared table, so start/join is refused and the tile explains ("1P View: No Sync"). Per-seat sync (each device showing its own seat) is the natural v2, likely via seat assignment at pairing.
- **Reset propagates; Game Mode Apply leaves.** Reset bumps the epoch and syncs table-wide. Apply, by contrast, *redefines* the game (player count, view, starting life) and settings don't sync — so it leaves the session rather than resetting the whole table to the applier's config.
- **Radio-on disables light sleep.** Light sleep powers down the modem and would drop packets, so while synced the loop idles on capped `vTaskDelay` instead. This has a real battery cost — sync is opt-in per game, sessions never persist across boots, and the radio is stopped before low-battery deep sleep, but a synced device will drain noticeably faster than a sleeping one.

## Known limitations

- **Same-player crossing commits are last-writer-wins** — roughly one exchange of false state, shrunk by the anti-entropy reply. Staggered edits are safe: a remote change to a locally-selected player cancels the pending preview, so duplicate entries don't double-apply. The cmd-damage and counter editors, however, stage absolutes at screen entry with no remote invalidation — a user parked on one can commit a stale value over a remote change.
- **Session ID is cleartext**: collision-proof, but sniffable/spoofable (input is clamped; no memory-safety exposure). Real crypto isn't feasible on broadcast ESP-NOW; accepted for a tabletop toy.
- **Damage log stays per-device** — remote changes appear as state, not events. Name sync is whole-roster LWW on a single version: concurrent renames of *different* players keep only one device's set.
- **Per-device settings leak**: elimination is derived under the committing device's auto-eliminate/track settings and adopted as fact, so settings-divergent tables get whichever device touched last.
- Commander damage saturates at 255 on the wire (display-only). No picker if two tables invite simultaneously; join timeout and Apply-leaves-session are silent (tile just shows "Sync Off"). Two harmless transients: simultaneous joiners can briefly show each other's pre-join state until the first beacon, and a pending preview can survive a remote reset when values coincide.

## Testing

- Firmware compiles for ESP32-S3 and the headless simulator builds; full 202-screenshot simulator matrix regenerated and reviewed (new screens included).
- Full two-device hardware pass on real boards at this exact head: pairing with code verification (start/join/leave), live mirroring of life, counters, commander damage, eliminations and elimination-undo, name inheritance at join plus mid-game rename propagation, duplicate-entry preview cancellation, mid-game reboot recovery via re-invite, shared reset, Game Mode Apply leaving the session, and the 1p-view refusal.

## Credits

Table Sync is based on a prototype by **kbratos** — please carry this credit into release/change notes, per their request.

