### PR TITLE
Adopt a 16MB custom partition table for the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAKE ?= make
 
 # ---- Arduino CLI ----
 # ARDUINO_CLI is set by config.mk (defaults to 'arduino-cli' in PATH)
-FQBN        := esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio
+FQBN        := esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio,PartitionScheme=custom
 EXTRA_URLS  := https://espressif.github.io/arduino-esp32/package_esp32_index.json
 
 .PHONY: help firmware firmware-flash firmware-deps check-arduino \

--- a/knobby/partitions.csv
+++ b/knobby/partitions.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x640000,
+app1,     app,  ota_1,   0x650000,0x640000,
+spiffs,   data, spiffs,  0xc90000,0x360000,
+coredump, data, coredump,0xFF0000,0x10000,


### PR DESCRIPTION
Split out of #113 so it can land (and be validated by CI) on its own — it's the foundation that branch builds on.

## Problem

The Makefile FQBN never set `PartitionScheme`, so every build has been silently using the default 4MB layout's **1.25MB app slot**, even though the boards have 16MB flash. The current app (~840KB) fits, but nothing radio-shaped ever will: linking the WiFi stack alone pushes the image past 1.3MB and the build fails with "text section exceeds available space".

## Change

- `knobby/partitions.csv` — the classic `default_16MB` layout (the core-3.x esp32s3 board no longer offers it as a named scheme): NVS at its standard `0x9000/0x5000`, otadata, dual **6.25MB** OTA app slots, SPIFFS, coredump. Sums to exactly 16MB.
- `Makefile` — adds `PartitionScheme=custom` to the FQBN, which makes the build pick up the sketch-folder CSV and corrects `upload.maximum_size`.

## Migration / safety

- NVS sits at the identical offset and size as the old table, and `make firmware-flash` never touches those sectors — **settings, names, and colors survive** the table migration. Verified by flashing two devices that previously ran the 4MB table; both kept their settings.
- Every upload also rewrites `boot_app0.bin` into otadata, so a device whose old otadata pointed at the old `app1` offset boots the new `ota_0` cleanly — no stale-slot boot risk.
- The partition CSV round-trips through the core's own `gen_esp32part.py` (the same tool the build invokes) with `--flash-size 16MB`.

One caveat for reviewers: with a custom scheme, arduino-cli reports sketch size against the full 16MB rather than the 6.25MB slot, so slot headroom has to be gauged manually.
