### PR TITLE
Add the custom partition scheme to the CI build command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Compile with arduino-cli
         run: |
-          arduino-cli compile --fqbn "esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio" knobby
+          arduino-cli compile --fqbn "esp32:esp32:esp32s3:FlashSize=16M,PSRAM=opi,USBMode=hwcdc,CDCOnBoot=cdc,FlashMode=qio,PartitionScheme=custom" knobby


### PR DESCRIPTION
Follow-up to #114: the CI compile step has its own FQBN copy, which still enforces the old default layout's 1.25MB app-slot size check. This was part of the #114 branch but the squash-merge predated the commit landing on the PR. One line; unblocks CI for any build that uses the 6.25MB slot (e.g. #113).