### PR TITLE
Display rotation setting + player menus face the acting player

### DIFF
--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -388,6 +388,7 @@ void reset_all_values(void)
 void knob_gui(void)
 {
     knob_hw_init();
+    display_apply_rotation(nvs_get_display_rotation());
     ensure_swipe_hint();
 
     build_intro_screen();
@@ -411,6 +412,7 @@ void knob_gui(void)
     build_mana_screen();
     build_settings_screen();
     build_battery_screen();
+    build_rotate_screen();
     build_table_sync_screen();
     build_damage_log_screen();
     build_quad_menus();
@@ -458,6 +460,11 @@ static void handle_knob_event(knob_event_t k)
         if (k == KNOB_LEFT)      change_brightness(-1);
         else if (k == KNOB_RIGHT) change_brightness(+1);
         refresh_settings_ui();
+    }
+    else if (lv_scr_act() == screen_rotate)
+    {
+        if (k == KNOB_LEFT)      change_display_rotation(-1);
+        else if (k == KNOB_RIGHT) change_display_rotation(+1);
     }
     else if (lv_scr_act() == screen_multiplayer)
     {

--- a/knobby/knob.c
+++ b/knobby/knob.c
@@ -384,6 +384,34 @@ void reset_all_values(void)
 }
 
 
+/* Recompute the effective display rotation whenever a player-scoped menu
+   screen loads or unloads, so menus can face the acting player (menu
+   facing setting). The callback is idempotent; hooking both events covers
+   every navigation path in and out. */
+static void menu_facing_screen_event(lv_event_t *e)
+{
+    (void)e;
+    menu_facing_refresh();
+}
+
+static void menu_facing_hook_screens(void)
+{
+    lv_obj_t *scoped[] = {
+        screen_player_menu, screen_eliminated_player_menu,
+        screen_player_all_damage, screen_counter_menu, screen_counter_edit,
+        screen_player_color_menu, screen_player_color_picker,
+        screen_player_name,
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(scoped) / sizeof(scoped[0]); i++) {
+        lv_obj_add_event_cb(scoped[i], menu_facing_screen_event,
+                            LV_EVENT_SCREEN_LOADED, NULL);
+        lv_obj_add_event_cb(scoped[i], menu_facing_screen_event,
+                            LV_EVENT_SCREEN_UNLOADED, NULL);
+    }
+}
+
 // ---------- init ----------
 void knob_gui(void)
 {
@@ -418,6 +446,7 @@ void knob_gui(void)
     build_quad_menus();
     build_game_mode_menu_screen();
     build_custom_life_screen();
+    menu_facing_hook_screens();
 
     refresh_main_ui();
     refresh_multiplayer_ui();

--- a/knobby/knob.h
+++ b/knobby/knob.h
@@ -49,6 +49,7 @@ void knob_notify_swipe_left(void);
 void knob_notify_swipe_right(void);
 float knob_read_battery_voltage(void);
 void scr_display_on(void);
+void display_apply_rotation(int rot);
 
 
 #ifdef __cplusplus

--- a/knobby/scr_st77916.h
+++ b/knobby/scr_st77916.h
@@ -298,6 +298,30 @@ void scr_display_on(void)
   if (lcd != NULL) lcd->displayOn();
 }
 
+/* Rotate the whole display in 90-degree steps via the panel's MADCTL flags.
+   The user rotation composes with the per-board base mirrors (XOR); the same
+   swap/mirror triple goes to the touch controller so touch and swipe
+   coordinates track the rotated image. */
+void display_apply_rotation(int rot)
+{
+  static const struct { bool swap; bool mx; bool my; } rot_flags[4] = {
+    {false, false, false},  /* 0   */
+    {true,  true,  false},  /* 90  */
+    {false, true,  true},   /* 180 */
+    {true,  false, true},   /* 270 */
+  };
+  if (lcd == NULL || touch == NULL) return;
+  rot &= 3;
+  bool mx = rot_flags[rot].mx ^ board->mirror_x;
+  bool my = rot_flags[rot].my ^ board->mirror_y;
+  lcd->swapXY(rot_flags[rot].swap);
+  lcd->mirrorX(mx);
+  lcd->mirrorY(my);
+  touch->swapXY(rot_flags[rot].swap);
+  touch->mirrorX(mx);
+  touch->mirrorY(my);
+}
+
 static bool tp_tracking = false;
 static lv_point_t tp_start = {0, 0};
 static lv_point_t tp_last = {0, 0};

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -10,6 +10,8 @@
 #include "game.h"
 #include "mana.h"
 #include "net_sync.h"
+#include "ui_mp.h"
+#include "ui_player_menu.h"
 
 // Forward declarations for cross-module calls
 extern void reset_all_values(void);
@@ -284,8 +286,38 @@ void change_display_rotation(int dir)
     int v = (nvs_get_display_rotation() +
              (dir > 0 ? 1 : DISPLAY_ROTATION_COUNT - 1)) % DISPLAY_ROTATION_COUNT;
     nvs_set_display_rotation(v);
-    display_apply_rotation(v);
     refresh_rotate_ui();
+    menu_facing_refresh();
+}
+
+/* Player-scoped menu screens that should face the acting player when
+   menu facing is enabled. */
+static bool screen_is_player_menu(lv_obj_t *screen)
+{
+    return screen == screen_player_menu ||
+           screen == screen_eliminated_player_menu ||
+           screen == screen_player_all_damage ||
+           screen == screen_counter_menu ||
+           screen == screen_counter_edit ||
+           screen == screen_player_color_menu ||
+           screen == screen_player_color_picker ||
+           screen == screen_player_name;
+}
+
+/* Single applier for the effective display rotation: the user's physical
+   rotation, plus the acting player's seat on player menus when the
+   "Menus: Face Player" toggle is on. Idempotent — recomputes from the
+   active screen, so any navigation path can call it safely. */
+void menu_facing_refresh(void)
+{
+    static int applied = -1;
+    int target = nvs_get_display_rotation();
+
+    if (nvs_get_menu_facing() && screen_is_player_menu(lv_scr_act()))
+        target = (target + mp_player_seat_rotation(menu_player)) & 3;
+    if (target == applied) return;
+    applied = target;
+    display_apply_rotation(target);
     /* Repaint the whole frame immediately: the panel's GRAM still holds the
        old orientation the instant the MADCTL flags change. */
     lv_obj_invalidate(lv_scr_act());
@@ -295,6 +327,11 @@ void change_display_rotation(int dir)
 static const char *random_first_label(int val)
 {
     return val ? "Random\nFirst\nON" : "Random\nFirst\nOFF";
+}
+
+static const char *menu_facing_label(int val)
+{
+    return val ? "Menus\nFace\nPlayer" : "Menus\nFixed";
 }
 
 static const char *multi_select_label(int val)
@@ -441,6 +478,7 @@ static const setting_item_t settings_items[] = {
     { .id = "multi-select",   .label = multi_select_label,     .color = toggle_color,      .get = nvs_get_multi_select,     .set = multi_select_set,         .count = 2 },
     { .id = "table-sync",     .fixed_label = "Table Sync\n(Experimental)", .navigate = open_table_sync_screen, .nav_screen = &screen_table_sync },
     { .id = "rotate",         .fixed_label = "Rotate\nScreen", .navigate = open_rotate_screen, .nav_screen = &screen_rotate },
+    { .id = "menu-facing",    .label = menu_facing_label,      .color = toggle_color,      .get = nvs_get_menu_facing,      .set = nvs_set_menu_facing,      .count = 2 },
 };
 #define SETTINGS_ITEM_COUNT ((int)(sizeof(settings_items) / sizeof(settings_items[0])))
 #define MAX_SETTINGS_PAGES  ((SETTINGS_ITEM_COUNT + 2) / 3)

--- a/knobby/src/settings.c
+++ b/knobby/src/settings.c
@@ -20,6 +20,7 @@ lv_obj_t *screen_quad_menu = NULL;
 lv_obj_t *screen_tools_menu = NULL;
 lv_obj_t *screen_settings = NULL;
 lv_obj_t *screen_battery = NULL;
+lv_obj_t *screen_rotate = NULL;
 
 // ---------- widgets ----------
 static lv_obj_t *arc_brightness = NULL;
@@ -27,6 +28,7 @@ static lv_obj_t *label_settings_value = NULL;
 static lv_obj_t *label_settings_hint = NULL;
 static lv_obj_t *label_settings_battery = NULL;
 static lv_obj_t *label_settings_battery_detail = NULL;
+static lv_obj_t *label_rotate_value = NULL;
 
 // ---------- quadrant menu builder ----------
 void build_quad_screen(lv_obj_t **screen, quad_item_t items[4])
@@ -130,6 +132,14 @@ void refresh_battery_ui(void)
         snprintf(detail_buf, sizeof(detail_buf), "%.2fV calibrated", battery_voltage);
         lv_label_set_text(label_settings_battery_detail, detail_buf);
     }
+}
+
+void refresh_rotate_ui(void)
+{
+    char buf[16];
+    if (label_rotate_value == NULL) return;
+    snprintf(buf, sizeof(buf), "%d°", nvs_get_display_rotation() * 90);
+    lv_label_set_text(label_rotate_value, buf);
 }
 
 // ---------- navigation ----------
@@ -261,6 +271,25 @@ void open_battery_screen(void)
     update_battery_measurement(true);
     refresh_battery_ui();
     lv_scr_load(screen_battery);
+}
+
+void open_rotate_screen(void)
+{
+    refresh_rotate_ui();
+    lv_scr_load(screen_rotate);
+}
+
+void change_display_rotation(int dir)
+{
+    int v = (nvs_get_display_rotation() +
+             (dir > 0 ? 1 : DISPLAY_ROTATION_COUNT - 1)) % DISPLAY_ROTATION_COUNT;
+    nvs_set_display_rotation(v);
+    display_apply_rotation(v);
+    refresh_rotate_ui();
+    /* Repaint the whole frame immediately: the panel's GRAM still holds the
+       old orientation the instant the MADCTL flags change. */
+    lv_obj_invalidate(lv_scr_act());
+    lv_refr_now(NULL);
 }
 
 static const char *random_first_label(int val)
@@ -411,6 +440,7 @@ static const setting_item_t settings_items[] = {
     { .id = "random-first",   .label = random_first_label,     .color = toggle_color,      .get = nvs_get_random_first,     .set = nvs_set_random_first,     .count = 2 },
     { .id = "multi-select",   .label = multi_select_label,     .color = toggle_color,      .get = nvs_get_multi_select,     .set = multi_select_set,         .count = 2 },
     { .id = "table-sync",     .fixed_label = "Table Sync\n(Experimental)", .navigate = open_table_sync_screen, .nav_screen = &screen_table_sync },
+    { .id = "rotate",         .fixed_label = "Rotate\nScreen", .navigate = open_rotate_screen, .nav_screen = &screen_rotate },
 };
 #define SETTINGS_ITEM_COUNT ((int)(sizeof(settings_items) / sizeof(settings_items[0])))
 #define MAX_SETTINGS_PAGES  ((SETTINGS_ITEM_COUNT + 2) / 3)
@@ -502,7 +532,7 @@ bool settings_handle_back(lv_obj_t *screen)
 
     for (i = 0; i < SETTINGS_ITEM_COUNT; i++) {
         if (settings_items[i].nav_screen != NULL && screen == *settings_items[i].nav_screen) {
-            if (screen == screen_settings) settings_save();
+            if (screen == screen_settings || screen == screen_rotate) settings_save();
             lv_scr_load(settings_pages[setting_page_of[i]]);
             return true;
         }
@@ -635,4 +665,31 @@ void build_battery_screen(void)
     lv_obj_set_style_text_color(label_settings_battery_detail, lv_color_hex(0x7A7A7A), 0);
     lv_obj_set_style_text_font(label_settings_battery_detail, &lv_font_montserrat_16, 0);
     lv_obj_align(label_settings_battery_detail, LV_ALIGN_CENTER, 0, 30);
+}
+
+void build_rotate_screen(void)
+{
+    screen_rotate = lv_obj_create(NULL);
+    lv_obj_set_size(screen_rotate, 360, 360);
+    lv_obj_set_style_bg_color(screen_rotate, lv_color_black(), 0);
+    lv_obj_set_style_border_width(screen_rotate, 0, 0);
+    lv_obj_set_scrollbar_mode(screen_rotate, LV_SCROLLBAR_MODE_OFF);
+
+    lv_obj_t *title = lv_label_create(screen_rotate);
+    lv_label_set_text(title, "Rotate Screen");
+    lv_obj_set_style_text_color(title, lv_color_white(), 0);
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_22, 0);
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 60);
+
+    label_rotate_value = lv_label_create(screen_rotate);
+    lv_label_set_text(label_rotate_value, "0°");
+    lv_obj_set_style_text_color(label_rotate_value, lv_color_white(), 0);
+    lv_obj_set_style_text_font(label_rotate_value, &lv_font_montserrat_32, 0);
+    lv_obj_align(label_rotate_value, LV_ALIGN_CENTER, 0, -10);
+
+    lv_obj_t *hint = lv_label_create(screen_rotate);
+    lv_label_set_text(hint, "Turn knob to rotate");
+    lv_obj_set_style_text_color(hint, lv_color_hex(0x6A6A6A), 0);
+    lv_obj_set_style_text_font(hint, &lv_font_montserrat_14, 0);
+    lv_obj_align(hint, LV_ALIGN_CENTER, 0, 40);
 }

--- a/knobby/src/settings.h
+++ b/knobby/src/settings.h
@@ -53,6 +53,7 @@ void open_settings_screen(void);
 void open_battery_screen(void);
 void open_rotate_screen(void);
 void change_display_rotation(int dir);
+void menu_facing_refresh(void);
 void open_table_sync_screen(void);
 
 #endif // _SETTINGS_H

--- a/knobby/src/settings.h
+++ b/knobby/src/settings.h
@@ -8,6 +8,7 @@ extern lv_obj_t *screen_quad_menu;
 extern lv_obj_t *screen_tools_menu;
 extern lv_obj_t *screen_settings;
 extern lv_obj_t *screen_battery;
+extern lv_obj_t *screen_rotate;
 extern lv_obj_t *screen_table_sync;
 
 // ---------- declarative settings ----------
@@ -35,11 +36,13 @@ void build_quad_screen(lv_obj_t **screen, quad_item_t items[4]);
 void build_quad_menus(void);
 void build_settings_screen(void);
 void build_battery_screen(void);
+void build_rotate_screen(void);
 void build_table_sync_screen(void);
 
 void refresh_settings_ui(void);
 void refresh_settings_pages_ui(void);
 void refresh_battery_ui(void);
+void refresh_rotate_ui(void);
 void refresh_table_sync_ui(void);
 
 bool settings_handle_back(lv_obj_t *screen);
@@ -48,6 +51,8 @@ int settings_item_page(const char *id);
 void open_quad_menu(void);
 void open_settings_screen(void);
 void open_battery_screen(void);
+void open_rotate_screen(void);
+void change_display_rotation(int dir);
 void open_table_sync_screen(void);
 
 #endif // _SETTINGS_H

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -10,6 +10,7 @@ static int cached_auto_dim = AUTO_DIM_OFF;
 static int cached_color_mode = 0;
 static int cached_deselect_timeout = 0; /* index: 0=never, 1=5s, 2=15s, 3=30s */
 static int cached_orientation = ORIENTATION_MODE_ABSOLUTE;
+static int cached_display_rotation = 0; /* physical rotation, degrees = value * 90 */
 static int cached_num_players = 4;
 static int cached_players_to_track = 1;
 static int cached_life_total = DEFAULT_LIFE_TOTAL;
@@ -34,6 +35,7 @@ void knob_nvs_init(void)
         int8_t lc_val = 0;
         int8_t dt_val = 0;
         int8_t rot_val = 0;
+        int8_t dr_val = 0;
         int8_t np_val = 4;
         int8_t pt_val = 1;
         int16_t lt_val = DEFAULT_LIFE_TOTAL;
@@ -43,6 +45,7 @@ void knob_nvs_init(void)
         nvs_get_i8(handle, "color_mode", &lc_val);
         nvs_get_i8(handle, "desel_time", &dt_val);
         nvs_get_i8(handle, "rotation", &rot_val);
+        nvs_get_i8(handle, "disp_rot", &dr_val);
         nvs_get_i8(handle, "num_players", &np_val);
         nvs_get_i8(handle, "track", &pt_val);
         nvs_get_i16(handle, "life_total", &lt_val);
@@ -53,6 +56,7 @@ void knob_nvs_init(void)
         cached_orientation = (rot_val < 0) ? ORIENTATION_MODE_ABSOLUTE
                 : (rot_val >= ORIENTATION_MODE_COUNT) ? ORIENTATION_MODE_ABSOLUTE
                                    : rot_val;
+        cached_display_rotation = (dr_val < 0 || dr_val >= DISPLAY_ROTATION_COUNT) ? 0 : dr_val;
         cached_brightness = clamp_brightness(bri_val);
         cached_num_players = (np_val < 1) ? 1 : (np_val > MAX_GAME_PLAYERS) ? MAX_GAME_PLAYERS : np_val;
         cached_players_to_track = (pt_val < 1) ? 1 : (pt_val > MAX_DISPLAY_PLAYERS) ? MAX_DISPLAY_PLAYERS : pt_val;
@@ -139,6 +143,17 @@ void nvs_set_orientation(int value)
     cached_orientation = (value < 0) ? ORIENTATION_MODE_ABSOLUTE
                                       : (value >= ORIENTATION_MODE_COUNT) ? ORIENTATION_MODE_ABSOLUTE
                                                                        : value;
+    settings_dirty = true;
+}
+
+int nvs_get_display_rotation(void)
+{
+    return cached_display_rotation;
+}
+
+void nvs_set_display_rotation(int value)
+{
+    cached_display_rotation = (value < 0 || value >= DISPLAY_ROTATION_COUNT) ? 0 : value;
     settings_dirty = true;
 }
 
@@ -235,6 +250,7 @@ void settings_save(void)
         nvs_set_i8(handle, "color_mode", (int8_t)cached_color_mode);
         nvs_set_i8(handle, "desel_time", (int8_t)cached_deselect_timeout);
         nvs_set_i8(handle, "rotation", (int8_t)cached_orientation);
+        nvs_set_i8(handle, "disp_rot", (int8_t)cached_display_rotation);
         nvs_set_i8(handle, "num_players", (int8_t)cached_num_players);
         nvs_set_i8(handle, "track", (int8_t)cached_players_to_track);
         nvs_set_i16(handle, "life_total", (int16_t)cached_life_total);

--- a/knobby/src/storage.c
+++ b/knobby/src/storage.c
@@ -11,6 +11,7 @@ static int cached_color_mode = 0;
 static int cached_deselect_timeout = 0; /* index: 0=never, 1=5s, 2=15s, 3=30s */
 static int cached_orientation = ORIENTATION_MODE_ABSOLUTE;
 static int cached_display_rotation = 0; /* physical rotation, degrees = value * 90 */
+static int cached_menu_facing = 0; /* 0=Fixed (default), 1=Face Player */
 static int cached_num_players = 4;
 static int cached_players_to_track = 1;
 static int cached_life_total = DEFAULT_LIFE_TOTAL;
@@ -77,6 +78,10 @@ void knob_nvs_init(void)
         int8_t ms_val = 0;
         nvs_get_i8(handle, "multi_sel", &ms_val);
         cached_multi_select = (ms_val != 0) ? 1 : 0;
+
+        int8_t mf_val = 0;
+        nvs_get_i8(handle, "menu_face", &mf_val);
+        cached_menu_facing = (mf_val != 0) ? 1 : 0;
 
         size_t nl_size = sizeof(cached_name_list);
         nvs_get_blob(handle, "name_list", cached_name_list, &nl_size);
@@ -154,6 +159,18 @@ int nvs_get_display_rotation(void)
 void nvs_set_display_rotation(int value)
 {
     cached_display_rotation = (value < 0 || value >= DISPLAY_ROTATION_COUNT) ? 0 : value;
+    settings_dirty = true;
+}
+
+// ---------- menu facing ----------
+int nvs_get_menu_facing(void)
+{
+    return cached_menu_facing;
+}
+
+void nvs_set_menu_facing(int value)
+{
+    cached_menu_facing = (value != 0) ? 1 : 0;
     settings_dirty = true;
 }
 
@@ -257,6 +274,7 @@ void settings_save(void)
         nvs_set_i8(handle, "auto_elim", (int8_t)cached_auto_eliminate);
         nvs_set_i8(handle, "rand_first", (int8_t)cached_random_first);
         nvs_set_i8(handle, "multi_sel", (int8_t)cached_multi_select);
+        nvs_set_i8(handle, "menu_face", (int8_t)cached_menu_facing);
         nvs_set_blob(handle, "name_list", cached_name_list, sizeof(cached_name_list));
         esp_err_t commit_err = nvs_commit(handle);
         nvs_close(handle);

--- a/knobby/src/storage.h
+++ b/knobby/src/storage.h
@@ -17,6 +17,8 @@ int nvs_get_deselect_timeout(void);
 void nvs_set_deselect_timeout(int value);
 int nvs_get_orientation(void);
 void nvs_set_orientation(int value);
+int nvs_get_display_rotation(void);
+void nvs_set_display_rotation(int value);
 
 int nvs_get_num_players(void);
 void nvs_set_num_players(int value);

--- a/knobby/src/storage.h
+++ b/knobby/src/storage.h
@@ -19,6 +19,8 @@ int nvs_get_orientation(void);
 void nvs_set_orientation(int value);
 int nvs_get_display_rotation(void);
 void nvs_set_display_rotation(int value);
+int nvs_get_menu_facing(void);
+void nvs_set_menu_facing(int value);
 
 int nvs_get_num_players(void);
 void nvs_set_num_players(int value);

--- a/knobby/src/types.h
+++ b/knobby/src/types.h
@@ -33,6 +33,9 @@
 #define ORIENTATION_MODE_TABLETOP 2
 #define ORIENTATION_MODE_COUNT    3
 
+// ---------- display rotation (physical, degrees = value * 90) ----------
+#define DISPLAY_ROTATION_COUNT 4
+
 // ---------- auto-dim timeout options ----------
 #define AUTO_DIM_OFF  0
 #define AUTO_DIM_15S  1

--- a/knobby/src/ui_mp.c
+++ b/knobby/src/ui_mp.c
@@ -326,6 +326,30 @@ static const mp_layout_spec_t *get_layout(int track)
     return &layout_4p;
 }
 
+/* Snap a player's seat angle to upright-or-flipped (display-rotation step
+   0 or 2) so menus can face them via the hardware rotation. Exact for
+   tabletop (only 0/180 there); centric's diagonal seats flip like tabletop
+   — top-half seats 180, bottom-half upright — since sideways (90/270)
+   menus read as weird rather than helpful. 0 in absolute mode,
+   single-player, or for a player without a panel. */
+int mp_player_seat_rotation(int player)
+{
+    int track = nvs_get_players_to_track();
+    int mode = nvs_get_orientation();
+    const mp_layout_spec_t *layout;
+    int i;
+
+    if (track < 2 || mode == ORIENTATION_MODE_ABSOLUTE) return 0;
+    layout = get_layout(track);
+    for (i = 0; i < layout->panel_count; i++) {
+        if (layout->panels[i].player_index == player) {
+            int16_t angle = layout->angle_fn(mode, i); /* 0.1-degree units */
+            return ((angle + 900) / 1800 * 2) & 3;
+        }
+    }
+    return 0;
+}
+
 /* ---------- per-panel refresh ---------- */
 static void refresh_counter_rows(const mp_panel_spec_t *spec, int16_t wedge_bis,
                                  lv_obj_t *panel, lv_obj_t **rows, lv_obj_t **value_labels,

--- a/knobby/src/ui_mp.h
+++ b/knobby/src/ui_mp.h
@@ -12,6 +12,8 @@ void rebuild_multiplayer_layout(int track);
 
 void refresh_multiplayer_ui(void);
 
+int mp_player_seat_rotation(int player);
+
 void select_kick_timer(void);
 
 #endif // _UI_MP_H

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -279,6 +279,18 @@ shot "setting_rotate_screen.png" --screen rotate
 shot "1p_rot90.png"  --screen 1p --track 1 --display-rotation 1
 shot "4p_rot180.png" --screen 4p --track 4 --display-rotation 2
 
+# Menu facing: player menus rotate toward the acting player
+for mf in 0 1; do
+    mf_name=("fixed" "face")
+    shot "setting_menufacing_${mf_name[$mf]}.png" --screen setting:menu-facing --menu-facing "$mf"
+done
+shot "player_menu_facing_2p_tabletop_p1.png" --screen player-menu \
+    --track 2 --orientation 2 --menu-facing 1 --menu-player 1
+shot "player_menu_facing_4p_centric_p2.png" --screen player-menu \
+    --track 4 --orientation 1 --menu-facing 1 --menu-player 2
+shot "player_menu_facing_off_p1.png" --screen player-menu \
+    --track 2 --orientation 2 --menu-facing 0 --menu-player 1
+
 shot "setting_tablesync_off.png"    --screen table-sync --track 4
 shot "setting_tablesync_ingame.png" --screen table-sync --track 4 --table-sync 1 --table-session 14242
 shot "setting_tablesync_1p.png"     --screen table-sync

--- a/sim/generate_matrix.sh
+++ b/sim/generate_matrix.sh
@@ -274,6 +274,11 @@ for ms in 0 1; do
     shot "setting_multiselect_${ms_name[$ms]}.png" --screen setting:multi-select --multi-select "$ms"
 done
 
+# Rotate screen + rotated life screens (physical display rotation)
+shot "setting_rotate_screen.png" --screen rotate
+shot "1p_rot90.png"  --screen 1p --track 1 --display-rotation 1
+shot "4p_rot180.png" --screen 4p --track 4 --display-rotation 2
+
 shot "setting_tablesync_off.png"    --screen table-sync --track 4
 shot "setting_tablesync_ingame.png" --screen table-sync --track 4 --table-sync 1 --table-session 14242
 shot "setting_tablesync_1p.png"     --screen table-sync

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -39,7 +39,14 @@ static void sim_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *
     int x, y;
     for (y = area->y1; y <= area->y2; y++) {
         for (x = area->x1; x <= area->x2; x++) {
-            framebuffer[y * SCREEN_W + x] = *color_p++;
+            /* Remap to mimic the panel's MADCTL rotation (see
+               display_apply_rotation in scr_st77916.h) */
+            switch (sim_display_rotation) {
+            case 1:  framebuffer[x * SCREEN_W + (SCREEN_W - 1 - y)] = *color_p++; break;
+            case 2:  framebuffer[(SCREEN_H - 1 - y) * SCREEN_W + (SCREEN_W - 1 - x)] = *color_p++; break;
+            case 3:  framebuffer[(SCREEN_H - 1 - x) * SCREEN_W + y] = *color_p++; break;
+            default: framebuffer[y * SCREEN_W + x] = *color_p++; break;
+            }
         }
     }
     lv_disp_flush_ready(drv);
@@ -117,6 +124,7 @@ static void nav_tools(void)      { lv_scr_load(screen_tools_menu); }
 static void nav_settings_menu(void) { lv_scr_load(settings_pages[0]); }
 static void nav_brightness(void) { open_settings_screen(); }
 static void nav_battery(void)    { open_battery_screen(); }
+static void nav_rotate(void)     { open_rotate_screen(); }
 static void nav_table_sync(void) { open_table_sync_screen(); }
 static void nav_dice(void)       { open_dice_screen(); }
 static void nav_damage_log(void) { open_damage_log_screen(); }
@@ -161,6 +169,7 @@ static const screen_entry_t all_screens[] = {
     {"settings-menu", nav_settings_menu},
     {"brightness",    nav_brightness},
     {"battery",       nav_battery},
+    {"rotate",        nav_rotate},
     {"table-sync",    nav_table_sync},
     {"dice",          nav_dice},
     {"damage-log",    nav_damage_log},
@@ -231,6 +240,7 @@ static void print_usage(void)
            "  --player-colors <csv>  Per-player custom color indices, e.g. 0,5,2,13\n"
            "  --player-override <csv> Per-player override flags, e.g. 0,1,0,0\n"
            "  --orientation <n>      0=absolute, 1=centric, 2=tabletop (default: 0)\n"
+           "  --display-rotation <n> Physical rotation: 0=0°, 1=90°, 2=180°, 3=270° (default: 0)\n"
            "  --brightness <n>       Brightness percent 1-100 (default: 30)\n"
            "  --auto-dim <n>         0=OFF, 1=15s, 2=30s, 3=60s (default: 0)\n"
            "  --deselect <n>         0=never, 1=5s, 2=15s, 3=30s (default: 0)\n"
@@ -263,7 +273,7 @@ static void print_usage(void)
            "  main 1p 2p 3p 4p intro menu tools settings-menu\n"
            "  settings-page<N>       Settings page N (1-based)\n"
            "  setting:<id>           Page hosting a setting (e.g. setting:autodim)\n"
-           "  brightness battery dice damage-log game-mode custom-life select\n"
+           "  brightness battery rotate dice damage-log game-mode custom-life select\n"
            "  damage player-menu rename all-damage counters-menu counter-edit\n"
            "  color-menu color-picker mana\n"
            "\nIntrospection:\n"
@@ -405,6 +415,8 @@ int main(int argc, char *argv[])
             sim_nvs_preset_i8("color_mode", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--orientation") == 0 && i + 1 < argc) {
             sim_nvs_preset_i8("rotation", (int8_t)atoi(argv[++i]));
+        } else if (strcmp(argv[i], "--display-rotation") == 0 && i + 1 < argc) {
+            sim_nvs_preset_i8("disp_rot", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--brightness") == 0 && i + 1 < argc) {
             brightness_val = atoi(argv[++i]);
             brightness_set = 1;

--- a/sim/sim_main.c
+++ b/sim/sim_main.c
@@ -241,6 +241,7 @@ static void print_usage(void)
            "  --player-override <csv> Per-player override flags, e.g. 0,1,0,0\n"
            "  --orientation <n>      0=absolute, 1=centric, 2=tabletop (default: 0)\n"
            "  --display-rotation <n> Physical rotation: 0=0°, 1=90°, 2=180°, 3=270° (default: 0)\n"
+           "  --menu-facing <n>      0=menus fixed, 1=player menus face the acting player (default: 0)\n"
            "  --brightness <n>       Brightness percent 1-100 (default: 30)\n"
            "  --auto-dim <n>         0=OFF, 1=15s, 2=30s, 3=60s (default: 0)\n"
            "  --deselect <n>         0=never, 1=5s, 2=15s, 3=30s (default: 0)\n"
@@ -417,6 +418,8 @@ int main(int argc, char *argv[])
             sim_nvs_preset_i8("rotation", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--display-rotation") == 0 && i + 1 < argc) {
             sim_nvs_preset_i8("disp_rot", (int8_t)atoi(argv[++i]));
+        } else if (strcmp(argv[i], "--menu-facing") == 0 && i + 1 < argc) {
+            sim_nvs_preset_i8("menu_face", (int8_t)atoi(argv[++i]));
         } else if (strcmp(argv[i], "--brightness") == 0 && i + 1 < argc) {
             brightness_val = atoi(argv[++i]);
             brightness_set = 1;
@@ -563,6 +566,7 @@ int main(int argc, char *argv[])
         } \
         if (menu_player_set) { \
             menu_player = menu_player_val; \
+            menu_facing_refresh(); \
         } \
         if (player_colors_set) { \
             for (i = 0; i < MAX_DISPLAY_PLAYERS; i++) \

--- a/sim/sim_sdl2.c
+++ b/sim/sim_sdl2.c
@@ -38,7 +38,15 @@ static void sim_flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *
     int x, y;
     for (y = area->y1; y <= area->y2; y++) {
         for (x = area->x1; x <= area->x2; x++) {
-            framebuffer[y * SCREEN_W + x] = *color_p++;
+            /* Remap to mimic the panel's MADCTL rotation (see
+               display_apply_rotation in scr_st77916.h); sdl_mouse_read
+               applies the inverse so clicks track the rotated image. */
+            switch (sim_display_rotation) {
+            case 1:  framebuffer[x * SCREEN_W + (SCREEN_W - 1 - y)] = *color_p++; break;
+            case 2:  framebuffer[(SCREEN_H - 1 - y) * SCREEN_W + (SCREEN_W - 1 - x)] = *color_p++; break;
+            case 3:  framebuffer[(SCREEN_H - 1 - x) * SCREEN_W + y] = *color_p++; break;
+            default: framebuffer[y * SCREEN_W + x] = *color_p++; break;
+            }
         }
     }
     lv_disp_flush_ready(drv);
@@ -214,10 +222,21 @@ static void handle_sdl_events(void)
 void sdl_mouse_read(lv_indev_drv_t * drv, lv_indev_data_t * data)
 {
     int x, y;
+    int lx, ly;
     uint32_t buttons = SDL_GetMouseState(&x, &y);
-    
-    data->point.x = (lv_coord_t)x;
-    data->point.y = (lv_coord_t)y;
+
+    /* Window coords are "physical panel" coords; map back to LVGL's logical
+       space (inverse of the sim_flush_cb remap), like the touch controller
+       does on hardware. */
+    switch (sim_display_rotation) {
+    case 1:  lx = y;                ly = SCREEN_W - 1 - x; break;
+    case 2:  lx = SCREEN_W - 1 - x; ly = SCREEN_H - 1 - y; break;
+    case 3:  lx = SCREEN_H - 1 - y; ly = x;                break;
+    default: lx = x;                ly = y;                break;
+    }
+
+    data->point.x = (lv_coord_t)lx;
+    data->point.y = (lv_coord_t)ly;
     data->state = (buttons & SDL_BUTTON(SDL_BUTTON_LEFT)) ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
 }
 

--- a/sim/sim_stubs.c
+++ b/sim/sim_stubs.c
@@ -214,6 +214,12 @@ float knob_read_battery_voltage(void) { return sim_battery_voltage; }
 
 void scr_display_on(void) { /* no-op in simulator */ }
 
+/* Physical display rotation: firmware sets the panel's MADCTL flags; the
+   sim records the value and the flush callbacks remap pixels to match. */
+int sim_display_rotation = 0;
+
+void display_apply_rotation(int rot) { sim_display_rotation = rot & 3; }
+
 /* ---- Random ---- */
 
 uint32_t esp_random(void) { return (uint32_t)rand(); }

--- a/sim/sim_stubs.h
+++ b/sim/sim_stubs.h
@@ -19,6 +19,10 @@ void sim_nvs_preset_u32(const char *key, uint32_t value);
 /* Controllable battery voltage for screenshots */
 extern float sim_battery_voltage;
 
+/* Physical display rotation (0-3, degrees = value * 90); set via
+   display_apply_rotation(), consumed by the sim flush callbacks */
+extern int sim_display_rotation;
+
 /* ESP32 attribute macros — empty on desktop */
 #ifndef IRAM_ATTR
 #define IRAM_ATTR


### PR DESCRIPTION
Closes #94. Closes #35.

Two features that share one mechanism — rotating the whole display in hardware via the panel's MADCTL swap/mirror flags, with the identical transform applied to the touch controller so taps and swipes track the rotated image automatically. Zero LVGL heap and zero per-frame CPU cost.

## Display rotation setting (#94)

- New **Rotate Screen** settings tile opens a dedicated screen; turning the knob rotates the entire display live in 90° steps, one step per detent. Back-swipe saves.
- Persists in NVS (`disp_rot`, distinct from the multiplayer layout key) and is restored before the first visible frame at boot.
- The user rotation composes with the per-board base mirrors (K518/K718 differ), so both boards behave identically.

## Player menus face the acting player (#35)

- New **Menus: Fixed / Face Player** toggle, default **Fixed** (existing devices keep current behavior).
- When enabled, player-scoped screens (player menu, counters, rename, color, commander damage, eliminated menu) rotate toward the player who opened them: 180° for top-half seats, upright otherwise — exact in tabletop mode; centric's diagonal seats flip the same way rather than rendering sideways. No-op in absolute mode and single-player.
- One idempotent applier recomputes the effective rotation from the active screen, hooked into `LV_EVENT_SCREEN_LOADED/UNLOADED` on the scoped screens, so every navigation path in and out restores the base rotation. It composes with the physical rotation setting.

## Simulator

`--display-rotation` and `--menu-facing` flags, a `rotate` screen target, MADCTL-equivalent pixel remap in both flush callbacks (with the inverse transform on SDL mouse input), and new matrix shots (rotate screen, rotated 1p/4p life screens, facing/fixed player menus).

## Testing

- Compiled for ESP32-S3; full screenshot matrix regenerated and reviewed.
- On-device (K518): all four rotations via the knob, persistence across reboot, menu facing in tabletop and centric layouts with touch/swipes tracking the rotated image.
- Not yet exercised: a K718-based board (different base-mirror composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
